### PR TITLE
Don't let the counting for build and infra nodes be clever, use fixed integer starting points

### DIFF
--- a/cookbooks/wombat/.kitchen.yml
+++ b/cookbooks/wombat/.kitchen.yml
@@ -12,10 +12,12 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  - name: centos-7.1
+  - name: centos-7.2
 
 suites:
   - name: default
     run_list:
-      - recipe[wombat::default]
+      - recipe[wombat::etc-hosts]
     attributes:
+      demo:
+        build-nodes: 2

--- a/cookbooks/wombat/attributes/default.rb
+++ b/cookbooks/wombat/attributes/default.rb
@@ -4,7 +4,6 @@ default['demo']['org'] = 'diprotodontia'
 default['demo']['build-nodes'] = 1
 default['demo']['infranodes'] = {}
 default['demo']['admin-user'] = 'ubuntu'
-default['demo']['admin-user'] = 'ubuntu'
 default['demo']['versions'].tap do |pkg|
   pkg['chefdk'] = '0.14.25'
   pkg['chef-server'] = '12.6.0'
@@ -17,8 +16,7 @@ end
 default['demo']['hosts'] = {
   'chef-server' => '172.31.54.10',
   'delivery' => '172.31.54.11',
-  'build-node-1' => '172.31.54.12',
-  'compliance' => '172.31.54.13'
+  'compliance' => '172.31.54.12'
 }
 
 default['demo']['users'] = {
@@ -36,6 +34,15 @@ default['demo']['users'] = {
     "last"      => "user",
     "email"     => "delivery@mammalia.biz",
     "password"  => "delivery!",
+    "roles"     => ["admin"],
+    "ssh_key"   => "/tmp/public.pub",
+    "pem"       => "/tmp/private.pem"
+  },
+  "workstation" => {
+    "first"     => "work",
+    "last"      => "station",
+    "email"     => "workstation@mammalia.biz",
+    "password"  => "workstation!",
     "roles"     => ["admin"],
     "ssh_key"   => "/tmp/public.pub",
     "pem"       => "/tmp/private.pem"

--- a/cookbooks/wombat/recipes/etc-hosts.rb
+++ b/cookbooks/wombat/recipes/etc-hosts.rb
@@ -5,7 +5,8 @@
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
 all_hosts = node['demo']['hosts'].to_h
-last_ip = all_hosts[all_hosts.keys.last].split('.')[-1].to_i
+build_ip = 100
+infra_ip = 200
 
 if File.exists?('/tmp/infranodes-info.json')
   infranodes = JSON(File.read('/tmp/infranodes-info.json'))
@@ -13,17 +14,17 @@ else
   infranodes = {}
 end
 
-1.upto(node['demo']['build_nodes'].to_i) do |i|
+1.upto(node['demo']['build-nodes'].to_i) do |i|
   build_node_name = "build-node-#{i}"
   next if all_hosts.key?(build_node_name)
-  last_ip += 1
-  all_hosts[build_node_name] = "172.31.54.#{last_ip}"
+  build_ip += 1
+  all_hosts[build_node_name] = "172.31.54.#{build_ip}"
 end
 
 infranodes.sort.each do |name, run_list|
   next if all_hosts.key?(name)
-  last_ip += 1
-  all_hosts[name] = "172.31.54.#{last_ip}"
+  infra_ip += 1
+  all_hosts[name] = "172.31.54.#{infra_ip}"
 end
 
 all_hosts.each do |hostname, ipaddress|


### PR DESCRIPTION
We were counting from the last node in the list, which wasn't sorted by IP so was easy to step on yourself. Build nodes count start at 101 and Infra Nodes at 201. The attribute for build-nodes had a typo so this wasn't working at all.
