### PR TITLE
Couple of fixes to get basic vagrant install working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 delivery.license
+chefautomate-validator.pem
+delivery-admin.creds
+delivery-user.pem
+delivery.creds
 .vagrant
 terraform.tfstate*
 terraform.tfvars

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
     echo "
     172.31.54.10 chef-server.chordata.biz
     172.31.54.11 delivery.chordata.biz
-    172.31.54.12 build-node.chordata.biz
+    172.31.54.101 build-node-1.chordata.biz
     " | sudo tee -a /etc/hosts
   HOSTS_FILE
 
@@ -75,11 +75,12 @@ Vagrant.configure(2) do |config|
     end
 
     d.vm.provision "shell", inline: <<-CONFIG_DS
-      sudo apt-get install chefdk #delivery
-      wget https://chef.bintray.com/current-apt/ubuntu/14.04/delivery_0.4.317-1_amd64.deb -O /tmp/delivery_0.4.317-1_amd64.deb
-      sudo dpkg -i /tmp/delivery_0.4.317-1_amd64.deb
-      [ -d /var/opt/delivery/license ] || sudo mkdir /var/opt/delivery/license/
-      sudo cp /vagrant/delivery.license /var/opt/delivery/license/delivery.license
+      echo "deb https://packages.chef.io/current-apt trusty  main" > chef-current.list
+      sudo mv chef-current.list /etc/apt/sources.list.d/
+      sudo apt-get update
+      sudo apt-get install chefdk=0.15.15-1 delivery=0.4.456-1
+      [ -d /var/opt/delivery/license ] || sudo mkdir -p /var/opt/delivery/license/
+      sudo cp /vagrant/delivery.license /var/opt/delivery/license/delivery.license || echo "delivery.license file missing" # apparently exiting doesn't work, so just warn
       [ -d /etc/delivery ] || sudo mkdir /etc/delivery && sudo chmod 0644 /etc/delivery
       sudo cp /vagrant/delivery-user.pem /etc/delivery/delivery.pem
     CONFIG_DS


### PR DESCRIPTION
- on the delivery node install,  use apt-get with specific version numbers from -current so that cachier can help
- correct an inconsistency on the build-node name so that part works
- add generated files to .gitignore

some thoughts:
- it might be better for now to set the versions of chefdk and delivery as variables and then consume them consistently throughout the Vagrantfile
- at some point soon we may need to be pulling chef-server and compliance from current also, depending on development efforts

This is great stuff, fantastic work!
