### PR TITLE
adds ~/.delivery/cli.toml

### DIFF
--- a/cookbooks/workstation/metadata.rb
+++ b/cookbooks/workstation/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cheeseplus@chef.io'
 license 'Apache 2.0'
 description 'Configures a Windows workstation'
 long_description 'Configures a Windows workstation'
-version '0.1.1'
+version '0.1.2'
 supports 'windows'
 
 depends 'chocolatey'

--- a/cookbooks/workstation/recipes/delivery.rb
+++ b/cookbooks/workstation/recipes/delivery.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: workstation
+# Recipe:: delivery
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+home = Dir.home
+
+directory "#{home}/.delivery/" do
+  action :create
+end
+
+template "#{home}/.delivery/cli.toml" do
+  source 'cli.toml.erb'
+  variables(
+    server: "#{node['demo']['domain_prefix']}delivery.#{node['demo']['domain']}",
+    ent: node['demo']['enterprise'],
+    org: node['demo']['org'],
+    user: node['demo']['users']['delivery']['first']
+  )
+end

--- a/cookbooks/workstation/spec/spec_helper.rb
+++ b/cookbooks/workstation/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/cookbooks/workstation/spec/unit/recipes/delivery_spec.rb
+++ b/cookbooks/workstation/spec/unit/recipes/delivery_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: workstation
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'workstation::delivery' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/workstation/templates/default/cli.toml.erb
+++ b/cookbooks/workstation/templates/default/cli.toml.erb
@@ -1,0 +1,7 @@
+server = "<%= @domain_prefix %>delivery.<%= @domain %>"
+enterprise = "<%= @ent %>"
+organization = "<%= @org %>"
+user = "<%= @user %>"
+api_protocol = "https"
+git_port = "8989"
+pipeline = "master"


### PR DESCRIPTION
this should allow any user to start running commands like `delivery init` anywhere in `~` and deeper, like say, in `~/.cookbooks/`. the system will prompt for the delivery user's password to be able to generate the token. fortunately most of us know that password, however, this step should probably get documented too.
