### PR TITLE
Fix rake aborting when infranodes: YAML key value is undefined

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,8 +42,12 @@ namespace :packer do
   task :build_infra do
     Rake::Task['cookbook:vendor'].invoke('infranodes')
     Rake::Task['cookbook:vendor'].reenable
-    infranodes.each do |name, _rl|
-      sh packer_build('infranodes', 'amazon-ebs', {'node-name' => name})
+    unless infranodes.nil?
+      infranodes.each do |name, _rl|
+        sh packer_build('infranodes', 'amazon-ebs', {'node-name' => name})
+      end
+    else
+      puts 'No infranodes to build!'
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -331,10 +331,10 @@ def parallel_pack(templates)
 end
 
 def infranodes
-  unless wombat['infranodes'].empty?
+  unless wombat['infranodes'].nil?
     wombat['infranodes'].sort
   else
-    {}
+    puts 'No infranodes listed in wombat.yml'
   end
 end
 


### PR DESCRIPTION
If I am a user running rake tasks that could potentially build infra nodes, but my wombat.yml has no infra nodes defined, then rake currently up and dies. Rake should inform me and handle this gracefully.

```
rake aborted!
NoMethodError: undefined method `empty?' for nil:NilClass
/Users/nweddle/repos/demos/wombat/Rakefile:334:in `infranodes'
/Users/nweddle/repos/demos/wombat/Rakefile:355:in `create_infranodes_json'
/Users/nweddle/repos/demos/wombat/Rakefile:177:in `packer_build'
/Users/nweddle/repos/demos/wombat/Rakefile:38:in `block (2 levels) in <top (required)>'
/Users/nweddle/repos/demos/wombat/Rakefile:62:in `block (3 levels) in <top (required)>'
/Users/nweddle/repos/demos/wombat/Rakefile:61:in `each'
/Users/nweddle/repos/demos/wombat/Rakefile:61:in `block (2 levels) in <top (required)>'
Tasks: TOP => packer:build_ami
```
