### PR TITLE
fixes ~/.ssh/config for real this time

### DIFF
--- a/cookbooks/workstation/recipes/certs-keys.rb
+++ b/cookbooks/workstation/recipes/certs-keys.rb
@@ -12,7 +12,9 @@ template "#{home}/.ssh/config" do
   source 'ssh_config.erb'
   variables(
     home: home,
-    ent: node['demo']['enterprise']
+    server: "#{node['demo']['domain_prefix']}delivery.#{node['demo']['domain']}",
+    ent: node['demo']['enterprise'],
+    user: node['demo']['users']['delivery']['first']
   )
 end
 

--- a/cookbooks/workstation/templates/default/ssh_config.erb
+++ b/cookbooks/workstation/templates/default/ssh_config.erb
@@ -1,8 +1,8 @@
-Host delivery-git
-  HostName delivery
+Host <%= @server %>
+  HostName <%= @server %>
   Port 8989
-  User delivery@<%= @ent %>
-  IdentityFile <%= @home %>\.ssh\id_rsa
+  User <%= @user -%>@<%= @ent %>
+  IdentityFile <%= @home -%>/.ssh/id_rsa
   IdentitiesOnly yes
   KexAlgorithms +diffie-hellman-group1-sha1
   StrictHostKeyChecking no
@@ -10,7 +10,7 @@ Host delivery-git
 Host *
   Port 22
   User ubuntu
-  IdentityFile <%= @home %>\.ssh\id_rsa
+  IdentityFile <%= @home -%>/.ssh/id_rsa
   IdentitiesOnly yes
   KexAlgorithms +diffie-hellman-group1-sha1
   StrictHostKeyChecking no


### PR DESCRIPTION
turns out delivery likes to be called by its full name.
