### PR TITLE
does not delete delivery.license, fixes #159

### DIFF
--- a/cookbooks/delivery/recipes/default.rb
+++ b/cookbooks/delivery/recipes/default.rb
@@ -122,7 +122,3 @@ delete_lines "Remove loopback entry we added earlier" do
   path "/etc/hosts"
   pattern "^127\.0\.0\.1.*localhost.*#{node['demo']['domain_prefix']}delivery\.#{node['demo']['domain']}.*delivery"
 end
-
-file '/var/opt/delivery/license/delivery.license' do
-  action :delete
-end


### PR DESCRIPTION
Some wombat-wrapper use cases need the license, others don’t. The onus should be on the wrapper.
