### PR TITLE
Chocolately is enforcing security that not all packages abide by - temp fix

### DIFF
--- a/cookbooks/workstation/recipes/default.rb
+++ b/cookbooks/workstation/recipes/default.rb
@@ -1,7 +1,9 @@
 include_recipe 'chocolatey'
 
 node['demo']['pkgs'].each do |pkg|
-  chocolatey pkg
+  chocolatey pkg do
+    options ({ '-allow-empty-checksums' => '' })
+  end
 end
 
 include_recipe 'workstation::certs-keys'


### PR DESCRIPTION
Chocolatey had some incident and now enforce checksums but not all the things in choco are using checksums yet.
