### PR TITLE
add support for chef environments

### DIFF
--- a/cookbooks/chef_server/recipes/cheffish.rb
+++ b/cookbooks/chef_server/recipes/cheffish.rb
@@ -49,17 +49,26 @@ end
 
 1.upto(build_node_num) do |i|
   build_node_name = "build-node-#{i}"
-  all_nodes[build_node_name] = []
+  all_nodes[build_node_name] = {}
 end
 
-infranodes.each do |infra_node_name, rl|
-  all_nodes[infra_node_name] = rl
+infranodes.each do |infra_node_name, info|
+  all_nodes[infra_node_name] = info
 end
 
-all_nodes.each do |node_name, rl|
+environments = infranodes.map { |_n, i| i['environment'] }.compact.uniq
+
+environments.each do |e|
+  chef_environment e do
+    chef_server conf_with_org
+  end
+end
+
+all_nodes.each do |node_name, info|
   chef_node node_name do
     tag 'delivery-build-node' if node_name.match(/^build-node/)
-    run_list rl unless rl.empty?
+    run_list info['run_list'] if info['run_list']
+    chef_environment info['environment'] if info['environment']
     chef_server conf_with_org
   end
 

--- a/cookbooks/wombat/recipes/etc-hosts.rb
+++ b/cookbooks/wombat/recipes/etc-hosts.rb
@@ -36,7 +36,7 @@ end
   all_hosts[wkstn_name] = "172.31.54.#{wkstn_ip}"
 end
 
-infranodes.sort.each do |name, run_list|
+infranodes.sort.each do |name, _info|
   next if all_hosts.key?(name)
   infra_ip += 1
   all_hosts[name] = "172.31.54.#{infra_ip}"

--- a/wombat.example.yml
+++ b/wombat.example.yml
@@ -14,9 +14,13 @@ infranodes:
   # Note: the cookbook content won't be automatically uploaded, only the node object will be created with the run list added,
   #       if the content doesn't exist at the first checkin the chef-client run will fail.
   # acceptance:
-  #   - recipe[bacon::chewy]
+  #   environment: web-acceptance
+  #   run_list:
+  #     - recipe[bacon::chewy]
   # delivered:
-  #   - recipe[bacon::crispy]
+  #   environment: web-delivered
+  #   run_list:
+  #     - recipe[bacon::crispy]
 version: 0.1.0
 products:
   chef: stable-12.13.37


### PR DESCRIPTION
- modifies the model of the `infranodes` hash, moving the run list to its own subkey of `run_list`, allowing us to extend this later on
- add an iterator of `chef_environment` resources for each unique environment defined on a node
- update `wombat.example.yml` with what this new format looks like
