### PR TITLE
Update AMI & add bootstrap_aws to build:image task

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ aws:
   keypair: keypair-ap-southeast-2
   source_ami:
     ubuntu: ami-8c4cb0ec
-    windows: ami-87c037e7
+    windows: ami-1712d877
 ```
 
 *NOTE:* workstation-passwd must meet the minimum Microsoft [Complexity Requirements](https://technet.microsoft.com/en-us/library/hh994562(v=ws.11).aspx)

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ namespace :build do
     end
     gen_ssh_key
     vendor_cookbooks(args[:template])
+    bootstrap_aws
     sh packer_build(args[:template], cloud)
   end
 

--- a/cookbooks/wombat/attributes/packer.rb
+++ b/cookbooks/wombat/attributes/packer.rb
@@ -4,7 +4,7 @@ default['wombat']['packer']['aws'].tap do |a|
   a['access_key'] = "xxxxx"
   a['keypair'] = "xxxxx"
   a['source_ami']['ubuntu'] = "ami-8c4cb0ec"
-  a['source_ami']['windows'] = "ami-87c037e7"
+  a['source_ami']['windows'] = "ami-1712d877"
 end
 
 default['wombat']['packer']['azure'].tap do |az|

--- a/packer/workstation.json
+++ b/packer/workstation.json
@@ -3,7 +3,7 @@
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-87c037e7",
+    "aws_source_ami": "ami-1712d877",
     "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
     "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
     "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",

--- a/wombat.example.yml
+++ b/wombat.example.yml
@@ -34,7 +34,7 @@ aws:
   keypair: keypair-ap-southeast-2
   source_ami:
     ubuntu: ami-8c4cb0ec
-    windows: ami-87c037e7
+    windows: ami-1712d877
 gce:
   zone: us-east1-b
   source_image:


### PR DESCRIPTION
Commit https://github.com/chef-cft/wombat/commit/452bcf8fc211f32939a69974190e8d5587268ec4 fixes https://github.com/chef-cft/wombat/issues/204 by adding the `bootstrap_aws` method to the `build:image` rake task.

And https://github.com/chef-cft/wombat/commit/5b3641d7197810d2e46935ce47fa1c9a6b1f9e77 fixes https://github.com/chef-cft/wombat/issues/203 by updating the Windows AMI to latest available from Amazon.
