### PR TITLE
Make configuration truly optional

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,11 +26,15 @@ The core of wombat is the binary `bin/wombat`.
 
 * If the TEMPLATE argument is not provided it will execute against all templates in `./packer/`
 
-`wombat deploy STACK`
+`wombat deploy STACK --update-lock --create-template`
 
 1. Create/update wombat.lock based on most recent Packer logs
 2. Create cfn/gdm configuration from lock data fed through template
 3. Deploy cfn/gdm stack
+
+`wombat deploy STACK`
+
+1. Deploy cfn/gdm stack
 
 `wombat outputs STACK`
 

--- a/cookbooks/workstation/recipes/browser.rb
+++ b/cookbooks/workstation/recipes/browser.rb
@@ -43,3 +43,17 @@ registry_key 'Set Chrome as default HTTPS protocol association' do
     {:name => 'ProgId', :type => :string, :data => 'ChromeHTML'}
   ]
 end
+
+# Enable ClearType for Chrome 52+
+registry_key "HKEY_CURRENT_USER\\Control Panel\\Desktop" do
+  values [{
+      :name => "FontSmoothing",
+      :type => :string,
+      :data => 2
+  },{
+      :name => "FontSmoothingType",
+      :type => :dword,
+      :data => 2
+  }]
+  action :create
+end

--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -117,7 +117,7 @@ class BuildRunner
   end
 
   def shell_out_command(command)
-    cmd = Mixlib::ShellOut.new(a_to_s(command), :timeout => timeout, live_stream: STDOUT)
+    cmd = Mixlib::ShellOut.new(a_to_s(command), :timeout => conf['timeout'], live_stream: STDOUT)
     cmd.run_command
     cmd
   end
@@ -139,9 +139,9 @@ class BuildRunner
     else
       base = template.split('.json')[0].tr('-', '_')
     end
-    rm_cmd = "rm -rf #{cookbook_dir}/#{base}/Berksfile.lock vendored-cookbooks/#{base}"
+    rm_cmd = "rm -rf #{conf['cookbook_dir']}/#{base}/Berksfile.lock vendored-cookbooks/#{base}"
     shell_out_command(rm_cmd)
-    vendor_cmd = "berks vendor -q -b #{cookbook_dir}/#{base}/Berksfile vendored-cookbooks/#{base}"
+    vendor_cmd = "berks vendor -q -b #{conf['cookbook_dir']}/#{base}/Berksfile vendored-cookbooks/#{base}"
     shell_out_command(vendor_cmd)
   end
 
@@ -161,7 +161,7 @@ class BuildRunner
     else
      log_name = "#{cloud}-#{template}-#{linux}"
     end
-    log_file = "#{log_dir}/#{log_name}.log"
+    log_file = "#{conf['log_dir']}/#{log_name}.log"
   end
 
   def packer_build_cmd(template, builder, options)
@@ -184,7 +184,7 @@ class BuildRunner
     end
 
     # TODO: fail if packer isn't found in a graceful way
-    cmd = %W(packer build #{packer_dir}/#{template}.json | tee #{log(template, builder, options)})
+    cmd = %W(packer build #{conf['packer_dir']}/#{template}.json | tee #{log(template, builder, options)})
     cmd.insert(2, "--only #{builder}")
     cmd.insert(2, "--var org=#{wombat['org']}")
     cmd.insert(2, "--var domain=#{wombat['domain']}")

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -152,7 +152,7 @@ module Common
     conf['packer_dir'] ||= 'packer'
     conf['log_dir'] ||= 'logs'
     conf['stack_dir'] ||= 'stacks'
-    conf['templates_dir'] ||= 'templates'
+    conf['template_dir'] ||= 'templates'
     conf['timeout'] ||= 7200
     conf['audio'] ||= false
     conf

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -41,9 +41,9 @@ module Common
 
   def bootstrap_aws
     @workstation_passwd = wombat['workstations']['password']
-    rendered = ERB.new(File.read('templates/bootstrap-aws.erb'), nil, '-').result(binding)
-    File.open("#{packer_dir}/scripts/bootstrap-aws.txt", 'w') { |file| file.puts rendered }
-    banner("Generated: #{packer_dir}/scripts/bootstrap-aws.txt")
+    rendered = ERB.new(File.read("#{conf['template_dir']}/bootstrap-aws.erb"), nil, '-').result(binding)
+    File.open("#{conf['packer_dir']}/scripts/bootstrap-aws.txt", 'w') { |file| file.puts rendered }
+    banner("Generated: #{conf['packer_dir']}/scripts/bootstrap-aws.txt")
   end
 
   def gen_x509_cert(hostname)
@@ -73,11 +73,11 @@ module Common
 
     cert.sign(rsa_key, OpenSSL::Digest::SHA256.new)
 
-    if File.exist?("#{key_dir}/#{hostname}.crt") && File.exist?("#{key_dir}/#{hostname}.key")
+    if File.exist?("#{conf['key_dir']}/#{hostname}.crt") && File.exist?("#{conf['key_dir']}/#{hostname}.key")
       puts "An x509 certificate already exists for #{hostname}"
     else
-      File.open("#{key_dir}/#{hostname}.crt", 'w') { |file| file.puts cert.to_pem }
-      File.open("#{key_dir}/#{hostname}.key", 'w') { |file| file.puts rsa_key.to_pem }
+      File.open("#{conf['key_dir']}/#{hostname}.crt", 'w') { |file| file.puts cert.to_pem }
+      File.open("#{conf['key_dir']}/#{hostname}.key", 'w') { |file| file.puts rsa_key.to_pem }
       puts "Certificate created for #{wombat['domain_prefix']}#{hostname}.#{wombat['domain']}"
     end
   end
@@ -90,11 +90,11 @@ module Common
 
     openssh_format = "#{type} #{data}"
 
-    if File.exist?("#{key_dir}/public.pub") && File.exist?("#{key_dir}/private.pem")
+    if File.exist?("#{conf['key_dir']}/public.pub") && File.exist?("#{conf['key_dir']}/private.pem")
       puts 'An SSH keypair already exists'
     else
-      File.open("#{key_dir}/public.pub", 'w') { |file| file.puts openssh_format }
-      File.open("#{key_dir}/private.pem", 'w') { |file| file.puts rsa_key.to_pem }
+      File.open("#{conf['key_dir']}/public.pub", 'w') { |file| file.puts openssh_format }
+      File.open("#{conf['key_dir']}/private.pem", 'w') { |file| file.puts rsa_key.to_pem }
       puts 'SSH Keypair created'
     end
   end
@@ -129,13 +129,13 @@ module Common
   end
 
   def create_infranodes_json
-    if File.exists?("#{packer_dir}/file/infranodes-info.json")
+    if File.exists?("#{conf['packer_dir']}/file/infranodes-info.json")
       current_state = JSON(File.read('files/infranodes-info.json'))
     else
       current_state = nil
     end
     return if current_state == infranodes # yay idempotence
-    File.open("#{packer_dir}/files/infranodes-info.json", 'w') do |f|
+    File.open("#{conf['packer_dir']}/files/infranodes-info.json", 'w') do |f|
       f.puts JSON.pretty_generate(infranodes)
     end
   end
@@ -144,28 +144,18 @@ module Common
     wombat['linux'].nil? ? 'ubuntu' : wombat['linux']
   end
 
-  def key_dir
-    wombat['conf'].nil? ? 'keys' : wombat['conf']['key_dir']
-  end
-
-  def cookbook_dir
-    wombat['conf'].nil? ? 'cookbooks' : wombat['conf']['cookbook_dir']
-  end
-
-  def packer_dir
-    wombat['conf'].nil? ? 'packer' : wombat['conf']['packer_dir']
-  end
-
-  def log_dir
-    wombat['conf'].nil? ? 'logs' : wombat['conf']['log_dir']
-  end
-
-  def stack_dir
-    wombat['conf'].nil? ? 'stacks' : wombat['conf']['stack_dir']
-  end
-
-  def timeout
-    wombat['conf']['timeout'] ||= 7200
+  def conf
+    conf = wombat['conf']
+    conf ||= {}
+    conf['key_dir'] ||= 'keys'
+    conf['cookbook_dir'] ||= 'cookbooks'
+    conf['packer_dir'] ||= 'packer'
+    conf['log_dir'] ||= 'logs'
+    conf['stack_dir'] ||= 'stacks'
+    conf['templates_dir'] ||= 'templates'
+    conf['timeout'] ||= 7200
+    conf['audio'] ||= false
+    conf
   end
 
   def is_mac?
@@ -173,6 +163,6 @@ module Common
   end
 
   def audio?
-    is_mac? && wombat['conf']['audio']
+    is_mac? && conf['audio']
   end
 end

--- a/lib/wombat/deploy.rb
+++ b/lib/wombat/deploy.rb
@@ -25,7 +25,7 @@ class DeployRunner
   private
 
   def create_stack(stack)
-    template_file = File.read("#{stack_dir}/#{@demo}.json")
+    template_file = File.read("#{conf['stack_dir']}/#{@demo}.json")
     cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
 
     banner("Creating CloudFormation stack")
@@ -45,7 +45,6 @@ class DeployRunner
   end
 
   def create_template
-    banner('Creating template...')
     region = lock['aws']['region']
     @chef_server_ami = lock['amis'][region]['chef-server']
     @automate_ami = lock['amis'][region]['automate']
@@ -68,13 +67,13 @@ class DeployRunner
     @demo = lock['name']
     @version = lock['version']
     @ttl = lock['ttl']
-    rendered_cfn = ERB.new(File.read('templates/cfn.json.erb'), nil, '-').result(binding)
-    File.open("#{stack_dir}/#{@demo}.json", 'w') { |file| file.puts rendered_cfn }
-    banner("Generate CloudFormation JSON: #{@demo}.json")
+    rendered_cfn = ERB.new(File.read("#{conf['template_dir']}/cfn.json.erb"), nil, '-').result(binding)
+    File.open("#{conf['stack_dir']}/#{@demo}.json", 'w') { |file| file.puts rendered_cfn }
+    banner("Generated: #{conf['stack_dir']}/#{@demo}.json")
   end
 
   def logs
-    Dir.glob("#{log_dir}/#{cloud}*.log").reject { |l| !l.match(wombat['linux']) }
+    Dir.glob("#{conf['log_dir']}/#{cloud}*.log").reject { |l| !l.match(wombat['linux']) }
   end
 
   def update_lock(cloud)

--- a/wombat.example.yml
+++ b/wombat.example.yml
@@ -43,7 +43,7 @@ conf:
   key_dir: 'keys'
   cookbook_dir: 'cookbooks'
   packer_dir: 'packer'
-  templates_dir: 'templates'
+  template_dir: 'templates'
   log_dir: 'logs'
   stack_dir: 'stacks'
   audio: false


### PR DESCRIPTION
- this make the `conf` section of the yaml fully optional, providing sane defaults
- refactored into one conf method
- add cleartype fix to Windows workstation cookbook because Chrome hates GDI
- renamed the configuration for the templates directory to `template_dir` to be consistent with other keys
