### PR TITLE
Rycar/reduce dc timeout

### DIFF
--- a/generator_files/cookbooks/chef_server/recipes/default.rb
+++ b/generator_files/cookbooks/chef_server/recipes/default.rb
@@ -45,6 +45,7 @@ chef_ingredient 'chef-server' do
   api_fqdn 'chef.#{node['demo']['domain']}'
   data_collector['root_url'] = 'https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}/data-collector/v0/'
   data_collector['token'] = "#{node['demo']['data_collector_token']}"
+  data_collector['timeout'] = '1'
   profiles["root_url"] = "https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}"
   EOH
 end
@@ -97,4 +98,11 @@ include_recipe 'chef_server::bootstrap_users'
 delete_lines "Remove temporary hostfile entry we added earlier" do
   path "/etc/hosts"
   pattern "^#{node['ipaddress']}.*#{node['demo']['domain_prefix']}chef\.#{node['demo']['domain']}.*chef"
+end
+
+# Temporary timeout was implemented to speed up builds. We can return to defaults now.
+delete_lines "Remove the data_collector timeout before we finish." do
+  path "/etc/opscode/chef-server.rb"
+  pattern "^.*data_collector.*timeout.*"
+  notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
 end

--- a/generator_files/cookbooks/chef_server/recipes/default.rb
+++ b/generator_files/cookbooks/chef_server/recipes/default.rb
@@ -99,14 +99,15 @@ end
 
 include_recipe 'chef_server::bootstrap_users'
 
-delete_lines "Remove temporary hostfile entry we added earlier" do
-  path "/etc/hosts"
-  pattern "^#{node['ipaddress']}.*#{node['demo']['domain_prefix']}chef\.#{node['demo']['domain']}.*chef"
-end
-
 # Temporary timeout no longer required. We can return to defaults now.
 delete_lines "Remove the data_collector timeout before we finish." do
   path "/etc/opscode/chef-server.rb"
   pattern "^.*data_collector.*timeout.*"
   notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
 end
+
+delete_lines "Remove temporary hostfile entry we added earlier" do
+  path "/etc/hosts"
+  pattern "^#{node['ipaddress']}.*#{node['demo']['domain_prefix']}chef\.#{node['demo']['domain']}.*chef"
+end
+

--- a/generator_files/cookbooks/chef_server/recipes/default.rb
+++ b/generator_files/cookbooks/chef_server/recipes/default.rb
@@ -45,9 +45,14 @@ chef_ingredient 'chef-server' do
   api_fqdn 'chef.#{node['demo']['domain']}'
   data_collector['root_url'] = 'https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}/data-collector/v0/'
   data_collector['token'] = "#{node['demo']['data_collector_token']}"
-  data_collector['timeout'] = '1'
   profiles["root_url"] = "https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}"
   EOH
+end
+
+# Temporarily reduced timeout to speed up the build.
+append_if_no_line "Add temporary hostsfile entry: #{node['ipaddress']}" do
+  path "/etc/opscode/chef-server.rb"
+  line "data_collector['timeout'] = '1'"
 end
 
 if node['platform'] == 'centos'
@@ -100,7 +105,7 @@ delete_lines "Remove temporary hostfile entry we added earlier" do
   pattern "^#{node['ipaddress']}.*#{node['demo']['domain_prefix']}chef\.#{node['demo']['domain']}.*chef"
 end
 
-# Temporary timeout was implemented to speed up builds. We can return to defaults now.
+# Temporary timeout no longer required. We can return to defaults now.
 delete_lines "Remove the data_collector timeout before we finish." do
   path "/etc/opscode/chef-server.rb"
   pattern "^.*data_collector.*timeout.*"

--- a/generator_files/cookbooks/chef_server/recipes/default.rb
+++ b/generator_files/cookbooks/chef_server/recipes/default.rb
@@ -39,11 +39,11 @@ chef_ingredient 'chef-server' do
   channel node['demo']['versions']['chef-server'].split('-')[0].to_sym
   version node['demo']['versions']['chef-server'].split('-')[1]
   config <<-EOH
-  api_fqdn 'chef.#{node['demo']['domain']}'
-  data_collector['root_url'] = 'https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}/data-collector/v0/'
-  data_collector['token'] = "#{node['demo']['data_collector_token']}"
-  profiles["root_url"] = "https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}"
-  EOH
+api_fqdn 'chef.#{node['demo']['domain']}'
+data_collector['root_url'] = 'https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}/data-collector/v0/'
+data_collector['token'] = "#{node['demo']['data_collector_token']}"
+profiles["root_url"] = "https://#{node['demo']['domain_prefix']}automate.#{node['demo']['domain']}"
+EOH
 end
 
 # Temporarily reduced timeout to speed up the build.


### PR DESCRIPTION
Combined the two chef_ingredient resources, and added a temporary 1ms timeout for the data collector so that an isolated build isn't hung up trying to connect to an automate server that likely doesn't exist yet. 