### PR TITLE
Azure custom images

### DIFF
--- a/generator_files/packer/automate.json
+++ b/generator_files/packer/automate.json
@@ -60,7 +60,9 @@
       "image_offer": "UbuntuServer",
       "image_sku": "14.04.5-LTS",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_pty": true
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/automate.json
+++ b/generator_files/packer/automate.json
@@ -125,7 +125,8 @@
                 "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/generator_files/packer/automate.json
+++ b/generator_files/packer/automate.json
@@ -1,115 +1,131 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-8e0b9499",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "ubuntu-1404-trusty-v20160809a",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "chefdk": "stable-latest",
-    "automate": "stable-latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "org": "marsupials",
-    "workstations": "1",
-    "ssh_username": "ubuntu"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "m4.large",
-      "communicator": "ssh",
-      "associate_public_ip_address": true,
-      "ssh_private_ip": false,
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true,
-      "ami_name": "automate-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-8e0b9499",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "ubuntu-1404-trusty-v20160809a",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "chefdk": "stable-latest",
+        "automate": "stable-latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "org": "marsupials",
+        "workstations": "1",
+        "ssh_username": "ubuntu"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "automate",
-      "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "14.04.5-LTS",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty": true
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "image_name": "automate-{{timestamp}}",
-      "machine_type": "n1-standard-2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/automate" ],
-      "run_list": [ "automate", "wombat::authorized-keys", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "workstations":  "{{user `workstations`}}",
-          "versions": {
-            "chefdk": "{{user `chefdk`}}",
-            "automate": "{{user `automate`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "m4.large",
+            "communicator": "ssh",
+            "associate_public_ip_address": true,
+            "ssh_private_ip": false,
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true,
+            "ami_name": "automate-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "automate",
+            "os_type": "Linux",
+            "image_publisher": "Canonical",
+            "image_offer": "UbuntuServer",
+            "image_sku": "14.04.5-LTS",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "image_name": "automate-{{timestamp}}",
+            "machine_type": "n1-standard-2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/automate"
+            ],
+            "run_list": [
+                "automate",
+                "wombat::authorized-keys",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "workstations": "{{user `workstations`}}",
+                    "versions": {
+                        "chefdk": "{{user `chefdk`}}",
+                        "automate": "{{user `automate`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "inline": [
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+            ],
+            "inline_shebang": "/bin/sh -x",
+            "type": "shell"
+        }
+    ]
 }

--- a/generator_files/packer/build-node.json
+++ b/generator_files/packer/build-node.json
@@ -60,7 +60,9 @@
       "image_offer": "UbuntuServer",
       "image_sku": "14.04.5-LTS",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_pty": true
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/build-node.json
+++ b/generator_files/packer/build-node.json
@@ -131,7 +131,8 @@
                 "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/generator_files/packer/build-node.json
+++ b/generator_files/packer/build-node.json
@@ -1,121 +1,137 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-8e0b9499",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "ubuntu-1404-trusty-v20160809a",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "chefdk": "stable-latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "node-number": "1",
-    "org": "marsupials",
-    "ssh_username": "ubuntu",
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "t2.micro",
-      "communicator": "ssh",
-      "associate_public_ip_address": true,
-      "ssh_private_ip": false,
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true,
-      "ami_name": "build-node-{{user `node-number`}}-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-8e0b9499",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "ubuntu-1404-trusty-v20160809a",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "chefdk": "stable-latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "node-number": "1",
+        "org": "marsupials",
+        "ssh_username": "ubuntu",
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "build-node",
-      "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "14.04.5-LTS",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty": true
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "image_name": "build-node-{{user `node-number`}}-{{timestamp}}",
-      "machine_type": "n1-standard-2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/build_node" ],
-      "run_list": [ "build_node", "wombat::authorized-keys", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "node-number": "{{user `node-number`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "workstations":  "{{user `workstations`}}",
-          "versions": {
-            "chefdk": "{{user `chefdk`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "t2.micro",
+            "communicator": "ssh",
+            "associate_public_ip_address": true,
+            "ssh_private_ip": false,
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true,
+            "ami_name": "build-node-{{user `node-number`}}-{{timestamp}}"
         },
-        "delivery_build": {
-          "trusted_certs": {
-            "chef-server": "/tmp/chef.crt",
-            "delivery": "/tmp/automate.crt"
-          }
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "build-node",
+            "os_type": "Linux",
+            "image_publisher": "Canonical",
+            "image_offer": "UbuntuServer",
+            "image_sku": "14.04.5-LTS",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "image_name": "build-node-{{user `node-number`}}-{{timestamp}}",
+            "machine_type": "n1-standard-2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/build_node"
+            ],
+            "run_list": [
+                "build_node",
+                "wombat::authorized-keys",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "node-number": "{{user `node-number`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "workstations": "{{user `workstations`}}",
+                    "versions": {
+                        "chefdk": "{{user `chefdk`}}"
+                    }
+                },
+                "delivery_build": {
+                    "trusted_certs": {
+                        "chef-server": "/tmp/chef.crt",
+                        "delivery": "/tmp/automate.crt"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "inline": [
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+            ],
+            "inline_shebang": "/bin/sh -x",
+            "type": "shell"
+        }
+    ]
 }

--- a/generator_files/packer/chef-server.json
+++ b/generator_files/packer/chef-server.json
@@ -60,7 +60,9 @@
       "image_offer": "UbuntuServer",
       "image_sku": "14.04.5-LTS",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_pty": true
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/chef-server.json
+++ b/generator_files/packer/chef-server.json
@@ -126,7 +126,8 @@
                 "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/generator_files/packer/chef-server.json
+++ b/generator_files/packer/chef-server.json
@@ -1,116 +1,132 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-8e0b9499",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "ubuntu-1404-trusty-v20160809a",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "chef-server": "stable-latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "manage": "stable-latest",
-    "org": "marsupials",
-    "push-jobs-server": "stable-latest",
-    "ssh_username": "ubuntu",
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "m4.large",
-      "communicator": "ssh",
-      "associate_public_ip_address": true,
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true,
-      "ami_name": "chef-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-8e0b9499",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "ubuntu-1404-trusty-v20160809a",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "chef-server": "stable-latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "manage": "stable-latest",
+        "org": "marsupials",
+        "push-jobs-server": "stable-latest",
+        "ssh_username": "ubuntu",
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "chef-server",
-      "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "14.04.5-LTS",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty": true
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "image_name": "chef-{{timestamp}}",
-      "machine_type": "n1-standard-2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/chef_server" ],
-      "run_list": [ "chef_server", "wombat::authorized-keys", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "workstations":  "{{user `workstations`}}",
-          "versions": {
-            "chef-server": "{{user `chef-server`}}",
-            "push-jobs-server": "{{user `push-jobs-server`}}",
-            "manage": "{{user `manage`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "m4.large",
+            "communicator": "ssh",
+            "associate_public_ip_address": true,
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true,
+            "ami_name": "chef-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "chef-server",
+            "os_type": "Linux",
+            "image_publisher": "Canonical",
+            "image_offer": "UbuntuServer",
+            "image_sku": "14.04.5-LTS",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "image_name": "chef-{{timestamp}}",
+            "machine_type": "n1-standard-2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/chef_server"
+            ],
+            "run_list": [
+                "chef_server",
+                "wombat::authorized-keys",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "workstations": "{{user `workstations`}}",
+                    "versions": {
+                        "chef-server": "{{user `chef-server`}}",
+                        "push-jobs-server": "{{user `push-jobs-server`}}",
+                        "manage": "{{user `manage`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "inline": [
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+            ],
+            "inline_shebang": "/bin/sh -x",
+            "type": "shell"
+        }
+    ]
 }

--- a/generator_files/packer/compliance.json
+++ b/generator_files/packer/compliance.json
@@ -122,7 +122,8 @@
                 "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/generator_files/packer/compliance.json
+++ b/generator_files/packer/compliance.json
@@ -1,112 +1,128 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-8e0b9499",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "ubuntu-1404-trusty-v20160809a",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "compliance": "stable-latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "org": "marsupials",
-    "ssh_username": "ubuntu",
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "t2.medium",
-      "communicator": "ssh",
-      "associate_public_ip_address": true,
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true,
-      "ami_name": "compliance-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-8e0b9499",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "ubuntu-1404-trusty-v20160809a",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "compliance": "stable-latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "org": "marsupials",
+        "ssh_username": "ubuntu",
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "compliance",
-      "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "14.04.5-LTS",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty": true
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "image_name": "compliance-{{timestamp}}",
-      "machine_type": "n1-standard-2",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/compliance" ],
-      "run_list": [ "compliance", "wombat::authorized-keys", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "workstations":  "{{user `workstations`}}",
-          "versions": {
-            "compliance": "{{user `compliance`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "t2.medium",
+            "communicator": "ssh",
+            "associate_public_ip_address": true,
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true,
+            "ami_name": "compliance-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "compliance",
+            "os_type": "Linux",
+            "image_publisher": "Canonical",
+            "image_offer": "UbuntuServer",
+            "image_sku": "14.04.5-LTS",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "image_name": "compliance-{{timestamp}}",
+            "machine_type": "n1-standard-2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/compliance"
+            ],
+            "run_list": [
+                "compliance",
+                "wombat::authorized-keys",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "workstations": "{{user `workstations`}}",
+                    "versions": {
+                        "compliance": "{{user `compliance`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "inline": [
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+            ],
+            "inline_shebang": "/bin/sh -x",
+            "type": "shell"
+        }
+    ]
 }

--- a/generator_files/packer/compliance.json
+++ b/generator_files/packer/compliance.json
@@ -58,7 +58,9 @@
       "image_offer": "UbuntuServer",
       "image_sku": "14.04.5-LTS",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_pty": true
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/infranodes-windows.json
+++ b/generator_files/packer/infranodes-windows.json
@@ -63,9 +63,11 @@
       "image_sku": "2012-R2-Datacenter",
       "location": "{{user `azure_location`}}",
       "vm_size": "Standard_DS3_v2",
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}",
+      "communicator": "winrm",
+      "winrm_use_ssl": "true",
+      "winrm_insecure": "true",
+      "winrm_port": 5986,
+      "winrm_timeout": "5m"
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/infranodes-windows.json
+++ b/generator_files/packer/infranodes-windows.json
@@ -1,125 +1,138 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-87c037e7",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "windows-server-2012-r2-dc-v20160809",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "node-name": "acceptance",
-    "org": "marsupials",
-    "ssh_username": "ubuntu",
-    "winrm_password": "RL9@T40BTmXh",
-    "winrm_username": "Administrator",
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "m4.large",
-      "communicator": "winrm",
-      "associate_public_ip_address": true,
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}",
-      "user_data_file": "{{template_dir}}/scripts/bootstrap-aws.txt",
-      "ami_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-87c037e7",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "windows-server-2012-r2-dc-v20160809",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "node-name": "acceptance",
+        "org": "marsupials",
+        "ssh_username": "ubuntu",
+        "winrm_password": "RL9@T40BTmXh",
+        "winrm_username": "Administrator",
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
-      "os_type": "Windows",
-      "image_publisher": "MicrosoftWindowsServer",
-      "image_offer": "WindowsServer",
-      "image_sku": "2012-R2-Datacenter",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "communicator": "winrm",
-      "winrm_use_ssl": "true",
-      "winrm_insecure": "true",
-      "winrm_port": 5986,
-      "winrm_timeout": "5m"
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "machine_type": "n1-highcpu-8",
-      "image_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
-      "communicator": "winrm",
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}",
-      "metadata": {
-        "windows-startup-script-url": "gs://wombat-bootstrap/win-bootstrap.ps1"
-      }
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "C:\\Windows\\Temp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "C:\\Windows\\Temp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel {{user `chef_channel`}} -version {{user `chef_ver`}}\"",
-      "guest_os_type": "windows",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/infranodes" ],
-      "run_list": [ "infranodes", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "node-name": "{{user `node-name`}}",
-          "org": "{{user `org`}}",
-          "versions": {
-              "chef": "{{user `chef_channel`}}-{{user `chef_ver`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "m4.large",
+            "communicator": "winrm",
+            "associate_public_ip_address": true,
+            "winrm_port": 5985,
+            "winrm_username": "{{user `winrm_username`}}",
+            "winrm_password": "{{user `winrm_password`}}",
+            "user_data_file": "{{template_dir}}/scripts/bootstrap-aws.txt",
+            "ami_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
+            "os_type": "Windows",
+            "image_publisher": "MicrosoftWindowsServer",
+            "image_offer": "WindowsServer",
+            "image_sku": "2012-R2-Datacenter",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "communicator": "winrm",
+            "winrm_use_ssl": "true",
+            "winrm_insecure": "true",
+            "winrm_port": 5986,
+            "winrm_timeout": "5m"
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "machine_type": "n1-highcpu-8",
+            "image_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
+            "communicator": "winrm",
+            "winrm_port": 5985,
+            "winrm_username": "{{user `winrm_username`}}",
+            "winrm_password": "{{user `winrm_password`}}",
+            "metadata": {
+                "windows-startup-script-url": "gs://wombat-bootstrap/win-bootstrap.ps1"
+            }
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "C:\\Windows\\Temp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "C:\\Windows\\Temp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel {{user `chef_channel`}} -version {{user `chef_ver`}}\"",
+            "guest_os_type": "windows",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/infranodes"
+            ],
+            "run_list": [
+                "infranodes",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "node-name": "{{user `node-name`}}",
+                    "org": "{{user `org`}}",
+                    "versions": {
+                        "chef": "{{user `chef_channel`}}-{{user `chef_ver`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "type": "windows-shell",
+            "inline": [
+                "C:\\Windows\\System32\\sysprep\\sysprep.exe /quiet /generalize /oobe /shutdown"
+            ]
+        }
+    ]
 }

--- a/generator_files/packer/infranodes-windows.json
+++ b/generator_files/packer/infranodes-windows.json
@@ -56,13 +56,16 @@
       "storage_account": "{{user `azure_storage_account`}}",
       "object_id": "{{user `azure_object_id`}}",
       "capture_container_name": "images",
-      "capture_name_prefix": "infranode-{{user `node-name`}}",
+      "capture_name_prefix": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
       "os_type": "Windows",
       "image_publisher": "MicrosoftWindowsServer",
       "image_offer": "WindowsServer",
       "image_sku": "2012-R2-Datacenter",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "winrm_port": 5985,
+      "winrm_username": "{{user `winrm_username`}}",
+      "winrm_password": "{{user `winrm_password`}}",
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/infranodes.json
+++ b/generator_files/packer/infranodes.json
@@ -122,7 +122,8 @@
                 "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
             ],
             "inline_shebang": "/bin/sh -x",
-            "type": "shell"
+            "type": "shell",
+            "skip_clean": true
         }
     ]
 }

--- a/generator_files/packer/infranodes.json
+++ b/generator_files/packer/infranodes.json
@@ -1,113 +1,128 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-8e0b9499",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "ubuntu-1404-trusty-v20160809a",
-    "build-nodes": "1",
-    "chef_channel": "stable",
-    "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
-    "chef_ver": "latest",
-    "domain": "animals.biz",
-    "domain_prefix": "",
-    "enterprise": "mammals",
-    "node-name": "acceptance",
-    "org": "marsupials",
-    "ssh_username": "{{user `ssh_username`}}",
-    "ssh_pty": true,
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "t2.medium",
-      "communicator": "ssh",
-      "associate_public_ip_address": true,
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true,
-      "ami_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-8e0b9499",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "ubuntu-1404-trusty-v20160809a",
+        "build-nodes": "1",
+        "chef_channel": "stable",
+        "chef_install_url": "curl -L https://omnitruck.chef.io/install.sh",
+        "chef_ver": "latest",
+        "domain": "animals.biz",
+        "domain_prefix": "",
+        "enterprise": "mammals",
+        "node-name": "acceptance",
+        "org": "marsupials",
+        "ssh_username": "{{user `ssh_username`}}",
+        "ssh_pty": true,
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "infranode-{{user `node-name`}}",
-      "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "14.04.5-LTS",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "image_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}",
-      "machine_type": "n1-standard-2",
-      "image_name": "chef-{{timestamp}}",
-      "ssh_username": "{{user `ssh_username`}}",
-      "ssh_pty" : true
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "/tmp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/infranodes" ],
-      "run_list": [ "infranodes", "wombat::authorized-keys", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "workstations":  "{{user `workstations`}}",
-          "node-name": "{{user `node-name`}}",
-          "versions": {
-              "chef": "{{user `chef_channel`}}-{{user `chef_ver`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "t2.medium",
+            "communicator": "ssh",
+            "associate_public_ip_address": true,
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true,
+            "ami_name": "automate-infranode-{{user `node-name`}}-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "infranode-{{user `node-name`}}",
+            "os_type": "Linux",
+            "image_publisher": "Canonical",
+            "image_offer": "UbuntuServer",
+            "image_sku": "14.04.5-LTS",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2"
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "image_name": "chef-{{timestamp}}",
+            "machine_type": "n1-standard-2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "/tmp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "{{user `chef_install_url`}} | sudo bash -s -- -c {{user `chef_channel`}} -v {{user `chef_ver`}}",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/infranodes"
+            ],
+            "run_list": [
+                "infranodes",
+                "wombat::authorized-keys",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "workstations": "{{user `workstations`}}",
+                    "node-name": "{{user `node-name`}}",
+                    "versions": {
+                        "chef": "{{user `chef_channel`}}-{{user `chef_ver`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+            "inline": [
+                "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+            ],
+            "inline_shebang": "/bin/sh -x",
+            "type": "shell"
+        }
+    ]
 }

--- a/generator_files/packer/infranodes.json
+++ b/generator_files/packer/infranodes.json
@@ -25,7 +25,8 @@
     "enterprise": "mammals",
     "node-name": "acceptance",
     "org": "marsupials",
-    "ssh_username": "ubuntu",
+    "ssh_username": "{{user `ssh_username`}}",
+    "ssh_pty": true,
     "workstations": "1"
   },
 

--- a/generator_files/packer/workstation.json
+++ b/generator_files/packer/workstation.json
@@ -61,7 +61,6 @@
       "image_sku": "2012-R2-Datacenter",
       "location": "{{user `azure_location`}}",
       "vm_size": "Standard_DS3_v2",
-
       "communicator": "winrm",
       "winrm_use_ssl": "true",
       "winrm_insecure": "true",

--- a/generator_files/packer/workstation.json
+++ b/generator_files/packer/workstation.json
@@ -54,13 +54,16 @@
       "storage_account": "{{user `azure_storage_account`}}",
       "object_id": "{{user `azure_object_id`}}",
       "capture_container_name": "images",
-      "capture_name_prefix": "infranode-{{user `node-name`}}",
+      "capture_name_prefix": "workstation-{{user `workstation-number`}}-{{timestamp}}",
       "os_type": "Windows",
       "image_publisher": "MicrosoftWindowsServer",
       "image_offer": "WindowsServer",
       "image_sku": "2012-R2-Datacenter",
       "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2"
+      "vm_size": "Standard_DS3_v2",
+      "winrm_port": 5985,
+      "winrm_username": "{{user `winrm_username`}}",
+      "winrm_password": "{{user `winrm_password`}}"
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/workstation.json
+++ b/generator_files/packer/workstation.json
@@ -61,9 +61,12 @@
       "image_sku": "2012-R2-Datacenter",
       "location": "{{user `azure_location`}}",
       "vm_size": "Standard_DS3_v2",
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}"
+
+      "communicator": "winrm",
+      "winrm_use_ssl": "true",
+      "winrm_insecure": "true",
+      "winrm_port": 5986,
+      "winrm_timeout": "5m"
     },
     {
       "type": "googlecompute",

--- a/generator_files/packer/workstation.json
+++ b/generator_files/packer/workstation.json
@@ -1,123 +1,137 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_region": "{{env `AWS_REGION`}}",
-    "aws_source_ami": "ami-87c037e7",
-    "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
-    "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-    "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
-    "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
-    "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
-    "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
-    "azure_location": "",
-    "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
-    "gce_zone": "{{env `GCE_ZONE`}}",
-    "gce_source_image": "windows-server-2012-r2-dc-v20160809",
-    "build-nodes": "1",
-    "chefdk": "stable-latest",
-    "domain_prefix": "",
-    "domain": "animals.biz",
-    "enterprise": "mammals",
-    "org": "marsupials",
-    "ssh_username": "ubuntu",
-    "winrm_password": "RL9@T40BTmXh",
-    "winrm_username": "Administrator",
-    "workstation-number": "1",
-    "workstations": "1"
-  },
-
-  "builders": [
-    { "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
-      "region": "{{user `aws_region`}}",
-      "source_ami": "{{user `aws_source_ami`}}",
-      "instance_type": "m4.large",
-      "communicator": "winrm",
-      "associate_public_ip_address": true,
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}",
-      "user_data_file": "{{template_dir}}/scripts/bootstrap-aws.txt",
-      "ami_name": "workstation-{{user `workstation-number`}}-{{timestamp}}"
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+        "aws_region": "{{env `AWS_REGION`}}",
+        "aws_source_ami": "ami-87c037e7",
+        "azure_client_id": "{{env `AZURE_CLIENT_ID`}}",
+        "azure_tenant_id": "{{env `AZURE_TENANT_ID`}}",
+        "azure_client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
+        "azure_subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+        "azure_storage_account": "{{env `AZURE_STORAGE_ACCOUNT`}}",
+        "azure_resource_group": "{{env `AZURE_RESOURCE_GROUP`}}",
+        "azure_object_id": "{{env `AZURE_OBJECT_ID`}}",
+        "azure_location": "",
+        "gce_account_file": "{{env `GCE_ACCOUNT_FILE`}}",
+        "gce_project_id": "{{env `GCE_PROJECT_ID`}}",
+        "gce_zone": "{{env `GCE_ZONE`}}",
+        "gce_source_image": "windows-server-2012-r2-dc-v20160809",
+        "build-nodes": "1",
+        "chefdk": "stable-latest",
+        "domain_prefix": "",
+        "domain": "animals.biz",
+        "enterprise": "mammals",
+        "org": "marsupials",
+        "ssh_username": "ubuntu",
+        "winrm_password": "RL9@T40BTmXh",
+        "winrm_username": "Administrator",
+        "workstation-number": "1",
+        "workstations": "1"
     },
-    {
-      "type": "azure-arm",
-      "subscription_id": "{{user `azure_subscription_id`}}",
-      "client_id": "{{user `azure_client_id`}}",
-      "client_secret": "{{user `azure_client_secret`}}",
-      "tenant_id": "{{user `azure_tenant_id`}}",
-      "resource_group_name": "{{user `azure_resource_group`}}",
-      "storage_account": "{{user `azure_storage_account`}}",
-      "object_id": "{{user `azure_object_id`}}",
-      "capture_container_name": "images",
-      "capture_name_prefix": "workstation-{{user `workstation-number`}}-{{timestamp}}",
-      "os_type": "Windows",
-      "image_publisher": "MicrosoftWindowsServer",
-      "image_offer": "WindowsServer",
-      "image_sku": "2012-R2-Datacenter",
-      "location": "{{user `azure_location`}}",
-      "vm_size": "Standard_DS3_v2",
-      "communicator": "winrm",
-      "winrm_use_ssl": "true",
-      "winrm_insecure": "true",
-      "winrm_port": 5986,
-      "winrm_timeout": "5m"
-    },
-    {
-      "type": "googlecompute",
-      "account_file": "{{user `gce_account_file`}}",
-      "project_id": "{{user `gce_project_id`}}",
-      "source_image": "{{user `gce_source_image`}}",
-      "zone": "{{user `gce_zone`}}",
-      "disk_type": "pd-ssd",
-      "disk_size": "80",
-      "machine_type": "n1-highcpu-8",
-      "image_name": "workstation-{{user `workstation-number`}}-{{timestamp}}",
-      "communicator": "winrm",
-      "winrm_port": 5985,
-      "winrm_username": "{{user `winrm_username`}}",
-      "winrm_password": "{{user `winrm_password`}}",
-      "metadata": {
-        "windows-startup-script-url": "gs://wombat-bootstrap/win-bootstrap.ps1"
-      }
-    }
-  ],
-
-  "provisioners" : [
-    {
-      "type": "file",
-      "source": "{{pwd}}/keys/",
-      "destination": "C:\\Windows\\Temp"
-    },
-    {
-      "type": "file",
-      "source": "{{pwd}}/files/",
-      "destination": "C:\\Windows\\Temp"
-    },
-    {
-      "type": "chef-solo",
-      "install_command": "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel {{user `chef_channel`}} -version {{user `chef_ver`}}\"",
-      "guest_os_type": "windows",
-      "cookbook_paths": [ "{{pwd}}/vendored-cookbooks/workstation" ],
-      "run_list": [ "workstation", "wombat::etc-hosts" ],
-      "json": {
-        "demo": {
-          "admin-user": "{{user `ssh_username`}}",
-          "domain_prefix": "{{user `domain_prefix`}}",
-          "domain": "{{user `domain`}}",
-          "enterprise": "{{user `enterprise`}}",
-          "org": "{{user `org`}}",
-          "workstation-number": "{{user `workstation-number`}}",
-          "build-nodes": "{{user `build-nodes`}}",
-          "versions": {
-            "chefdk": "{{user `chefdk`}}"
-          }
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_source_ami`}}",
+            "instance_type": "m4.large",
+            "communicator": "winrm",
+            "associate_public_ip_address": true,
+            "winrm_port": 5985,
+            "winrm_username": "{{user `winrm_username`}}",
+            "winrm_password": "{{user `winrm_password`}}",
+            "user_data_file": "{{template_dir}}/scripts/bootstrap-aws.txt",
+            "ami_name": "workstation-{{user `workstation-number`}}-{{timestamp}}"
+        },
+        {
+            "type": "azure-arm",
+            "subscription_id": "{{user `azure_subscription_id`}}",
+            "client_id": "{{user `azure_client_id`}}",
+            "client_secret": "{{user `azure_client_secret`}}",
+            "tenant_id": "{{user `azure_tenant_id`}}",
+            "resource_group_name": "{{user `azure_resource_group`}}",
+            "storage_account": "{{user `azure_storage_account`}}",
+            "object_id": "{{user `azure_object_id`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "workstation-{{user `workstation-number`}}-{{timestamp}}",
+            "os_type": "Windows",
+            "image_publisher": "MicrosoftWindowsServer",
+            "image_offer": "WindowsServer",
+            "image_sku": "2012-R2-Datacenter",
+            "location": "{{user `azure_location`}}",
+            "vm_size": "Standard_DS3_v2",
+            "communicator": "winrm",
+            "winrm_username": "packer",
+            "winrm_use_ssl": "true",
+            "winrm_insecure": "true",
+            "winrm_port": 5986,
+            "winrm_timeout": "5m"
+        },
+        {
+            "type": "googlecompute",
+            "account_file": "{{user `gce_account_file`}}",
+            "project_id": "{{user `gce_project_id`}}",
+            "source_image": "{{user `gce_source_image`}}",
+            "zone": "{{user `gce_zone`}}",
+            "disk_type": "pd-ssd",
+            "disk_size": "80",
+            "machine_type": "n1-highcpu-8",
+            "image_name": "workstation-{{user `workstation-number`}}-{{timestamp}}",
+            "communicator": "winrm",
+            "winrm_port": 5985,
+            "winrm_username": "{{user `winrm_username`}}",
+            "winrm_password": "{{user `winrm_password`}}",
+            "metadata": {
+                "windows-startup-script-url": "gs://wombat-bootstrap/win-bootstrap.ps1"
+            }
         }
-      }
-    }
-  ]
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{pwd}}/keys/",
+            "destination": "C:\\Windows\\Temp"
+        },
+        {
+            "type": "file",
+            "source": "{{pwd}}/files/",
+            "destination": "C:\\Windows\\Temp"
+        },
+        {
+            "type": "chef-solo",
+            "install_command": "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel {{user `chef_channel`}} -version {{user `chef_ver`}}\"",
+            "guest_os_type": "windows",
+            "cookbook_paths": [
+                "{{pwd}}/vendored-cookbooks/workstation"
+            ],
+            "run_list": [
+                "workstation",
+                "wombat::etc-hosts"
+            ],
+            "json": {
+                "demo": {
+                    "admin-user": "{{user `ssh_username`}}",
+                    "domain_prefix": "{{user `domain_prefix`}}",
+                    "domain": "{{user `domain`}}",
+                    "enterprise": "{{user `enterprise`}}",
+                    "org": "{{user `org`}}",
+                    "workstation-number": "{{user `workstation-number`}}",
+                    "build-nodes": "{{user `build-nodes`}}",
+                    "versions": {
+                        "chefdk": "{{user `chefdk`}}"
+                    }
+                }
+            }
+        },
+        {
+            "only": [
+                "azure-arm"
+            ],
+            "type": "windows-shell",
+            "inline": [
+                "C:\\Windows\\System32\\sysprep\\sysprep.exe /quiet /generalize /oobe /shutdown"
+            ]
+        }
+    ]
 }

--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -21,16 +21,24 @@
 
     "adminPassword": {
       "type": "string",
-      "metdata": {
+      "metadata": {
         "description": "Password associated with the specified user"
       },
       "defaultValue": "<%= @password %>"
+    },
+
+    "shortUniqueLength": {
+      "type": "int",
+      "metadata": {
+        "description": "Number of characters to be take from the unique string to make a short unique string"
+      },
+      "defaultValue": 4
     }
 
   },
   "variables": {
     
-    "unique": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name]",
+    "unique": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name)]",
     "uniqueShort": "[substring(variables('unique'), 0, parameters('shortUniqueLength'))]",
 
     "location": "[resourceGroup().location]",
@@ -77,7 +85,8 @@
           "external": {
             "domainNameLabel": "[concat('ws-', variables('uniqueShort'))]",
             "allocationMethod": "dynamic"
-          },
+          }
+        },
         "buildnode": {
           "internal": {
             "addressPrefix": "10.0.0.",
@@ -90,23 +99,12 @@
             "allocationMethod": "static"
           }
         }
-        }
       }
     },
 
     "customData": "#cloud-config\nmanage_etc_hosts: true\n\npackage_update: false"
   },
   "resources": [
-    
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('sa').name",
-      "apiVersion": "2015-06-15",
-      "location": "[variables('location')]",
-      "properties": {
-        "accountType": "[variables('sa').type]"
-      }
-    },
 
     {
       "type": "Microsoft.Network/virtualNetworks",
@@ -123,7 +121,7 @@
           {
             "name": "[variables('network').subnet.name]",
             "properties": {
-              "addressPrefix": "[variables('network').subnet.addressPrefix"
+              "addressPrefix": "[variables('network').subnet.addressPrefix]"
             }
           }
         ]
@@ -135,7 +133,7 @@
 <% 1.upto(@workstations) do |i| -%>
 
     {
-      "type": "Mirosoft.Network/publicIPAddresses",
+      "type": "Microsoft.Network/publicIPAddresses",
       "name": "Workstation-<%= i.to_s %>-PublicIPAddress",
       "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
@@ -153,7 +151,8 @@
       "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('network').virtual.name)]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('network').virtual.name)]",
+        "Microsoft.Network/publicIPAddresses/Workstation-<%= i.to_s %>-PublicIPAddress"
       ],
       "properties": {
         "ipConfigurations": [
@@ -161,7 +160,7 @@
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "[variables('network').ipAddresses.workstation.internal.allocationMethod]",
-              "privateIPAddress": "[concat(variables('network').ipAddresses.workstation.internal.addressPrefix, '<%= 200 + i %>']",
+              "privateIPAddress": "[concat(variables('network').ipAddresses.workstation.internal.addressPrefix, '<%= 200 + i %>')]",
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'Workstation-<%= i.to_s %>-PublicIPAddress')]"
               },
@@ -201,7 +200,7 @@
             "createOption": "FromImage",
             "caching": "ReadWrite",
             "image": {
-              "uri": "<%= @workstation_uri[i] %>"
+              "uri": "<%= @workstation_ami[i] %>"
             },
             "vhd": {
               "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/workstation-<%= i.to_s %>-osdisk.vhd')]"
@@ -236,7 +235,7 @@
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "[variables('network').ipAddresses.buildnode.internal.allocationMethod]",
-              "privateIPAddress": "[concat(variables('network').ipAddresses.buildnode.internal.addressPrefix, '<%= 50 + i %>']",
+              "privateIPAddress": "[concat(variables('network').ipAddresses.buildnode.internal.addressPrefix, '<%= 50 + i %>')]",
               "subnet": {
                 "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('network').virtual.name), '/subnets/', variables('network').subnet.name)]"
               }
@@ -273,7 +272,7 @@
             "createOption": "FromImage",
             "caching": "ReadWrite",
             "image": {
-              "uri": "<%= @build_node_uri[i] %>"
+              "uri": "<%= @build_node_ami[i] %>"
             },
             "vhd": {
               "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/buildnode-<%= i.to_s %>-osdisk.vhd')]"
@@ -364,7 +363,7 @@
 
 <% end %>
 
-    {
+  {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "ChefServer-NIC",
       "apiVersion": "2015-06-15",
@@ -404,8 +403,8 @@
           "vmSize": "Standard_F4s"
         },
         "osProfile": {
-          "computerName": "[concat('chef-', variables('uniqueShort')]",
-          "customData": "[base64(concat(variables('customData', '\n\nruncmd:\n - hostnamectl set-hostname chef\n - chef-server-ctl reconfigure')))]",
+          "computerName": "[concat('chef-', variables('uniqueShort'))]",
+          "customData": "[base64(concat(variables('customData'), '\n\nruncmd:\n - hostnamectl set-hostname chef\n - chef-server-ctl reconfigure'))]",
           "adminUsername": "ubuntu",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -463,7 +462,7 @@
       "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/AutomateSrever-NIC"
+        "Microsoft.Network/networkInterfaces/AutomateServer-NIC"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Automate Server')]"
@@ -473,8 +472,8 @@
           "vmSize": "Standard_F4s"
         },
         "osProfile": {
-          "computerName": "[concat('chef-', variables('uniqueShort')]",
-          "customData": "[base64(concat(variables('customData', '\n\nruncmd:\n - hostnamectl set-hostname automate\n - chef-server-ctl reconfigure')))]",
+          "computerName": "[concat('chef-', variables('uniqueShort'))]",
+          "customData": "[base64(concat(variables('customData'), '\n\nruncmd:\n - hostnamectl set-hostname automate\n - chef-server-ctl reconfigure'))]",
           "adminUsername": "ubuntu",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -542,8 +541,8 @@
           "vmSize": "Standard_F4s"
         },
         "osProfile": {
-          "computerName": "[concat('chef-', variables('uniqueShort')]",
-          "customData": "[base64(concat(variables('customData', '\n\nruncmd:\n - hostnamectl set-hostname compliance\n - chef-server-ctl reconfigure')))]",
+          "computerName": "[concat('chef-', variables('uniqueShort'))]",
+          "customData": "[base64(concat(variables('customData'), '\n\nruncmd:\n - hostnamectl set-hostname compliance\n - chef-server-ctl reconfigure'))]",
           "adminUsername": "ubuntu",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -570,7 +569,6 @@
         }
       }
     }
-
   ],
   "outputs": {
 

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -280,6 +280,9 @@ module Common
         @chef_server_uri = lock['amis'][region]['chef-server']
         @automate_uri = lock['amis'][region]['automate']
         @compliance_uri = lock['amis'][region]['compliance']
+
+        # set an admin password for the machines that are created
+        @password = "aAan0orxevCma4gG"
       when 'gce'
         region = lock['gce']['zone']
       end

--- a/lib/wombat/deploy.rb
+++ b/lib/wombat/deploy.rb
@@ -1,5 +1,7 @@
 require 'wombat/common'
 require 'aws-sdk'
+require 'ms_rest_azure'
+require 'azure_mgmt_resources'
 
 class DeployRunner
   include Common
@@ -14,34 +16,70 @@ class DeployRunner
   end
 
   def start
-    case cloud
-    when 'aws'
-      update_lock(cloud) if lock_opt
-      update_template(cloud) if template_opt
-      create_stack(stack)
-    end
+    update_lock(cloud) if lock_opt
+    update_template(cloud) if template_opt
+    create_stack(stack)
   end
 
   private
 
   def create_stack(stack)
-    template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
-    cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
 
-    banner("Creating CloudFormation stack")
-    resp = cfn.create_stack({
-      stack_name: "#{stack}",
-      template_body: template_file,
-      capabilities: ["CAPABILITY_IAM"],
-      on_failure: "DELETE",
-      parameters: [
-        {
-          parameter_key: "KeyName",
-          parameter_value: lock['aws']['keypair'],
-        }
-      ]
-    })
-    puts "Created: #{resp.stack_id}"
+    # Deploy the template to the correct stack
+    case @cloud
+    when "aws"
+
+      template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
+      cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
+
+      banner("Creating CloudFormation stack")
+      resp = cfn.create_stack({
+        stack_name: "#{stack}",
+        template_body: template_file,
+        capabilities: ["CAPABILITY_IAM"],
+        on_failure: "DELETE",
+        parameters: [
+          {
+            parameter_key: "KeyName",
+            parameter_value: lock['aws']['keypair'],
+          }
+        ]
+      })
+      puts "Created: #{resp.stack_id}"
+    when "azure"
+
+      banner("Creating Azure RM stack")
+
+      # determine the path to the arm template
+      template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
+
+      # determine the name of the deployment
+      deployment_name = format('deploy-%s', Time.now().to_i)
+
+      # Create the connection to Azure using the information in the environment variables
+      subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
+      tenant_id = ENV['AZURE_TENANT_ID']
+      client_id = ENV['AZURE_CLIENT_ID']
+      client_secret = ENV['AZURE_CLIENT_SECRET']
+      resource_group = ENV['AZURE_RESOURCE_GROUP']
+
+      token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+      azure_conn = MsRest::TokenCredentials.new(token_provider)
+
+      # Create a resource client so that the template can be deployed
+      resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
+      resource_management_client.subscription_id = subscription_id
+
+      # Create the deployment definition
+      deployment = Azure::ARM::Resources::Models::Deployment.new
+      deployment.properties = Azure::ARM::Resources::Models::DeploymentProperties.new
+      deployment.properties.mode = Azure::ARM::Resources::Models::DeploymentMode::Incremental
+      deployment.properties.template = JSON.parse(template_file)
+
+      # Perform the deployment to the named resource group
+      response = resource_management_client.deployments.create_or_update(resource_group, deployment_name, deployment)
+
+    end
   end
 
 end

--- a/wombat-cli.gemspec
+++ b/wombat-cli.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'parallel', '~> 1.9'
   gem.add_dependency 'aws-sdk', '~> 2.5'
   gem.add_dependency 'racker', '~> 0.2'
+  gem.add_dependency 'azure_mgmt_resources', '~> 0.8'
 end


### PR DESCRIPTION
Updated the Packer templates to have the correct setting for creating custom images in Azure.  When building windows machines the username and password for `winrm` is not specified and the default packer username is used.  This is because there is an issue setting the password for the user in settings - or at least I could not find the correct setting.

Added the Ruby Azure SDK Resources gem to the `gemspec` as this is required to connect and deploy ARM templates to Azure.

The Azure template ERB file has been debugged and typos removed

The `common.rb` file has a new variable for ERB which is used to set the admin password.  This should be dynamically generated as it is static at the moment.  This is required because Azure must have an `adminUsername` and `adminPassword` when it creates a machine.

`deploy.rb` has been modified so that it understands how to deploy to Azure using the SDK

Azure requires custom images to have been prepared so that it can spin them up into working machines.  For Linux this is `waagent` and for Windows it is `sysprep`.  I have added these as final commands from `automate` and the `workstation`.  These commands will only run when using the `azure-arm` builder.  This needs some testing as not sure the commands are 100% correct yet.