### PR TITLE
Fix posh-git PowerShell module loading

### DIFF
--- a/generator_files/cookbooks/workstation/metadata.rb
+++ b/generator_files/cookbooks/workstation/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cheeseplus@chef.io'
 license 'Apache 2.0'
 description 'Configures a Windows workstation'
 long_description 'Configures a Windows workstation'
-version '0.2.5'
+version '0.2.6'
 supports 'windows'
 
 depends 'chocolatey'

--- a/generator_files/cookbooks/workstation/templates/default/ise_profile.ps1.erb
+++ b/generator_files/cookbooks/workstation/templates/default/ise_profile.ps1.erb
@@ -1,5 +1,5 @@
-# Load posh-git example profile
-. '<%= @home %>\Documents\WindowsPowerShell\Modules\posh-git\profile.example.ps1'
+# Load posh-git
+Import-Module posh-git
 
 # Load PSReadline
 Import-Module PSReadLine

--- a/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
+++ b/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
@@ -28,12 +28,8 @@ describe command('choco list -l git-credential-manager-for-windows') do
   its(:stdout) { should match(/1 packages installed\./) }
 end
 
-describe command('choco list -l visualstudiocode') do
-  its(:stdout) { should match(/1 packages installed\./) }
-end
-
-describe command('choco list -l poshgit') do
-  its(:stdout) { should match(/1 packages installed\./) }
+describe command('Get-Module -ListAvailable -Name posh-git') do
+  its(:stdout) { should match(/Script     0.7.0      posh-git/) }
 end
 
 describe file('C:\Users\Administrator\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1') do

--- a/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
+++ b/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
@@ -35,3 +35,7 @@ end
 describe command('choco list -l poshgit') do
   its(:stdout) { should match(/1 packages installed\./) }
 end
+
+describe file('C:\Users\Administrator\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1') do
+  its('content') { should match(/Import-Module posh-git/) }
+end


### PR DESCRIPTION
Fixes https://github.com/chef-cft/bjc/issues/370
We simply need to call out that we want to load the post-git PowerShell module.
Caused by breaking change from the posh-git project: https://github.com/dahlbyk/posh-git/pull/376