### PR TITLE
Modified IP range in Azure to match Wombat attributes

### DIFF
--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -52,34 +52,34 @@
     "network": {
       "virtual": {
         "name": "ChefAutomate-VNET",
-        "addressPrefix": "10.0.0.0/24"
+        "addressPrefix": "172.31.54.0/24"
       },
       "subnet": {
         "name": "ChefAutomate-Subnet",
-        "addressPrefix": "10.0.0.0/24"
+        "addressPrefix": "172.31.54.0/24"
       },
       "ipAddresses": {
         "chef": {
           "internal": {
-            "address": "10.0.0.4",
+            "address": "172.31.54.10",
             "allocationMethod": "static"
           }
         },
         "automate": {
           "internal": {
-            "address": "10.0.0.5",
+            "address": "172.31.54.11",
             "allocationMethod": "static"
           }
         },
         "compliance": {
           "internal": {
-            "address": "10.0.0.6",
+            "address": "172.31.54.12",
             "allocationMethod": "static"
           }
         },
         "workstation": {
           "internal": {
-            "addressPrefix": "10.0.0.",
+            "addressPrefix": "172.31.54.",
             "allocationMethod": "static"
           },
           "external": {
@@ -89,13 +89,13 @@
         },
         "buildnode": {
           "internal": {
-            "addressPrefix": "10.0.0.",
+            "addressPrefix": "172.31.54.",
             "allocationMethod": "static"
           }
         },
         "infranode": {
           "internal": {
-            "addressPrefix": "10.0.0.",
+            "addressPrefix": "172.31.54.",
             "allocationMethod": "static"
           }
         }


### PR DESCRIPTION
The template for Azure was creating a virtual network with a subnet of 10.0.0.0/24 but this did not match the attributes and hosts for the Automate cluster.

Have modified the template to use the correct network range.