### PR TITLE
Creation and removal of stack within Azure

### DIFF
--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -16,7 +16,7 @@
       "metadata": {
         "description": "Name of the storage account that should be used to store the machine disks"
       },
-      "defaultValue": "<%= ENV['AZURE_STORAGE_ACCOUNT'] %>"
+      "defaultValue": "<%= @storage_account %>"
     },
 
     "adminPassword": {

--- a/generator_files/wombat.yml
+++ b/generator_files/wombat.yml
@@ -59,7 +59,8 @@ aws:
     windows: ami-1c7ad77c
     centos: ami-6d1c2007
 azure:
-  location: westus
+  location: eastus
+  storage_account: 
 gce:
   zone: us-east1-b
   project: wombat-gce

--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -3,6 +3,9 @@ require 'wombat/common'
 require 'wombat/crypto'
 require 'mixlib/shellout'
 require 'parallel'
+require 'ms_rest_azure'
+require 'azure_mgmt_resources'
+require 'azure_mgmt_storage'
 
 module Wombat
   class BuildRunner
@@ -31,6 +34,9 @@ module Wombat
       banner("Generating SSH keypair (if necessary)")
       gen_ssh_key
 
+      # If running on azure ensure that the resource group and storage account exist
+      prepare_azure if builder == "azure-arm"
+
       time = Benchmark.measure do
         banner("Starting build for templates: #{templates}")
         aws_region_check if builder == 'amazon-ebs'
@@ -51,6 +57,65 @@ module Wombat
     end
 
     private
+
+    def prepare_azure()
+
+      # Ensure that a storage acocunt has been specified, if it has not error
+      if wombat['azure']['storage_account'].nil?
+        puts "\nA storage account name must be specified in wombat.yml, e.g.\n  openssl rand -base64 12\nEnsure all lowercase and no special characters"
+        exit
+      end
+
+      # Using environment variables connect to azure
+      subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
+      tenant_id = ENV['AZURE_TENANT_ID']
+      client_id = ENV['AZURE_CLIENT_ID']
+      client_secret = ENV['AZURE_CLIENT_SECRET']
+
+      token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+      azure_conn = MsRest::TokenCredentials.new(token_provider)
+
+      # Create a resource to create the resource group if it does not exist
+      resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
+      resource_management_client.subscription_id = subscription_id
+
+      # Create a storage account client to create the stoarge account if it does not exist
+      storage_management_client = Azure::ARM::Storage::StorageManagementClient.new(azure_conn)
+      storage_management_client.subscription_id = subscription_id
+
+      # Check that the resource group exists
+      banner(format("Checking for resource group: %s", wombat['name']))
+      status = resource_management_client.resource_groups.check_existence(wombat['name'])
+      if status
+        puts "resource group already exists"
+      else
+        puts format("creating new resource group in '%s'", wombat['azure']['location'])
+
+        # Set the parameters for the resource group
+        resource_group = Azure::ARM::Resources::Models::ResourceGroup.new
+        resource_group.location = wombat['azure']['location']
+
+        # Create the resource group
+        resource_management_client.resource_groups.create_or_update(wombat['name'], resource_group)
+      end
+
+      # Check to see if the storage account already exists
+      banner(format("Checking for storage account: %s", wombat['azure']['storage_account']))
+
+      # Create the storage account in the resource group
+      # NOTE:  This should have a test to see if the storage account exists and it available however the
+      # Azure Ruby SDK has an issue with the check_name_availability method and comes back with an error
+      # This would normally be done through an ARM template, but in this case needs to exist before Packer can run
+      storage_account = Azure::ARM::Storage::Models::StorageAccountCreateParameters.new
+      storage_account.location = wombat['azure']['location']
+      sku = Azure::ARM::Storage::Models::Sku.new
+      sku.name = 'Standard_LRS'
+      storage_account.sku = sku
+      storage_account.kind = Azure::ARM::Storage::Models::Kind::Storage
+
+      storage_management_client.storage_accounts.create(wombat['name'], wombat['azure']['storage_account'], storage_account)
+
+    end
 
     def build(template, options)
       bootstrap_aws if options['os'] == 'windows'

--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -17,6 +17,7 @@ module Wombat
       @parallel = opts.parallel
       @wombat_yml = opts.wombat_yml unless opts.wombat_yml.nil?
       @debug = opts.debug
+      @no_vendor = opts.vendor
     end
 
     def start
@@ -34,7 +35,7 @@ module Wombat
         banner("Starting build for templates: #{templates}")
         aws_region_check if builder == 'amazon-ebs'
         templates.each do |t|
-          vendor_cookbooks(t)
+          vendor_cookbooks(t) unless @no_vendor
         end
 
         if parallel.nil?
@@ -53,8 +54,7 @@ module Wombat
 
     def build(template, options)
       bootstrap_aws if options['os'] == 'windows'
-      #shell_out_command(packer_build_cmd(template, builder, options))
-      puts packer_build_cmd(template, builder, options)
+      shell_out_command(packer_build_cmd(template, builder, options))
     end
 
     def build_parallel(templates)
@@ -234,6 +234,8 @@ module Wombat
       cmd.insert(2, "--var gce_source_image=#{source_image}")
       cmd.insert(2, "--var azure_location=#{wombat['azure']['location']}")
       cmd.insert(2, "--var ssh_username=#{linux}")
+      cmd.insert(2, "--var azure_resource_group=#{wombat['name']}")
+      cmd.insert(2, "--var azure_storage_account=#{wombat['azure']['storage_account']}")
       cmd.insert(2, "--debug") if @debug
       cmd.join(' ')
     end

--- a/lib/wombat/cli.rb
+++ b/lib/wombat/cli.rb
@@ -72,6 +72,10 @@ module Wombat
             opts.on("--debug", "Run in debug mode.") do |opt|
               options.debug = opt
             end
+
+            opts.on("--novendorcookbooks", "Do not vendor cookbooks") do |opt|
+              options.vendor = opt
+            end
           },
           argv: templates_argv_proc
         },

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -218,6 +218,7 @@ module Wombat
           @iam_roles = lock['aws']['iam_roles']
         when 'azure'
           region = lock['azure']['location']
+          @storage_account = lock['azure']['storage_account']
           template_file = "arm.json.erb"
           @chef_server_uri = lock['amis'][region]['chef-server']
           @automate_uri = lock['amis'][region]['automate']

--- a/lib/wombat/delete.rb
+++ b/lib/wombat/delete.rb
@@ -1,5 +1,7 @@
 require 'wombat/common'
 require 'aws-sdk'
+require 'ms_rest_azure'
+require 'azure_mgmt_resources'
 
 module Wombat
   class DeleteRunner
@@ -19,12 +21,38 @@ module Wombat
     private
 
     def cfn_delete_stack(stack)
-      cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
 
-      resp = cfn.delete_stack({
-        stack_name: stack,
-      })
-      banner("Deleted #{stack}")
+      # Delete the stack from the correct platform
+      case @cloud
+      when "aws"
+        cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
+
+        resp = cfn.delete_stack({
+          stack_name: stack,
+        })
+        banner("Deleted #{stack}")
+
+      when "azure"
+
+        # Create the connection to Azure using the information in the environment variables
+        subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
+        tenant_id = ENV['AZURE_TENANT_ID']
+        client_id = ENV['AZURE_CLIENT_ID']
+        client_secret = ENV['AZURE_CLIENT_SECRET']
+
+        token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+        azure_conn = MsRest::TokenCredentials.new(token_provider)
+
+        # Create a resource client so that the resource group can be deleted
+        resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
+        resource_management_client.subscription_id = subscription_id
+
+        banner(format("Deleting resource group: %s", stack))
+
+        resource_management_client.resource_groups.begin_delete(stack)
+
+
+      end
     end
   end
 end

--- a/lib/wombat/deploy.rb
+++ b/lib/wombat/deploy.rb
@@ -62,7 +62,6 @@ module Wombat
       tenant_id = ENV['AZURE_TENANT_ID']
       client_id = ENV['AZURE_CLIENT_ID']
       client_secret = ENV['AZURE_CLIENT_SECRET']
-      resource_group = ENV['AZURE_RESOURCE_GROUP']
 
       token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
       azure_conn = MsRest::TokenCredentials.new(token_provider)
@@ -78,7 +77,7 @@ module Wombat
       deployment.properties.template = JSON.parse(template_file)
 
       # Perform the deployment to the named resource group
-      response = resource_management_client.deployments.create_or_update(resource_group, deployment_name, deployment)
+      response = resource_management_client.deployments.create_or_update(stack, deployment_name, deployment)
 
     end
     end

--- a/wombat-cli.gemspec
+++ b/wombat-cli.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'parallel', '~> 1.9'
   gem.add_dependency 'aws-sdk', '~> 2.5'
   gem.add_dependency 'azure_mgmt_resources', '~> 0.8'
+  gem.add_dependency 'azure_mgmt_storage', '~> 0.8'
 end


### PR DESCRIPTION
Settings in the `wombat.yml` file are now used to determine the resource group and the storage account.  The `name:` (which is the stack name) is used for the name of the resource group.

A new parameter under `azure:` called `storage_account:` must be specified, if not then wombat will error with a message stating how it can be created.

(This is the first iteration and it might be that the storage account name is determined automatically).

This means that the `storage_account` and `resource_group` no longer needs to be specified as environment variables.  This has been reflected in the ERB template for Azure.

When a build occurs the system will now create the `resource_group` and `storage_account` if they do not already exist.  This has been done using the Azure SDK Ruby.

Finally a stack can be removed from Azure using the `wombat delete` command.