### PR TITLE
Azure updates 2017-02-07

### DIFF
--- a/generator_files/packer/infranodes-windows.json
+++ b/generator_files/packer/infranodes-windows.json
@@ -131,7 +131,8 @@
             ],
             "type": "windows-shell",
             "inline": [
-                "C:\\Windows\\System32\\sysprep\\sysprep.exe /quiet /generalize /oobe /shutdown"
+                "cd C:\\Windows\\System32\\sysprep",
+                "sysprep.exe /quiet /generalize /oobe /shutdown"
             ]
         }
     ]

--- a/generator_files/packer/infranodes.json
+++ b/generator_files/packer/infranodes.json
@@ -26,7 +26,6 @@
         "node-name": "acceptance",
         "org": "marsupials",
         "ssh_username": "{{user `ssh_username`}}",
-        "ssh_pty": true,
         "workstations": "1"
     },
     "builders": [
@@ -59,7 +58,9 @@
             "image_offer": "UbuntuServer",
             "image_sku": "14.04.5-LTS",
             "location": "{{user `azure_location`}}",
-            "vm_size": "Standard_DS3_v2"
+            "vm_size": "Standard_DS3_v2",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_pty": true
         },
         {
             "type": "googlecompute",

--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -307,7 +307,7 @@
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "[variables('network').ipAddresses.infranode.internal.allocationMethod]",
-              "privateIPAddress": "[concat(variables('network').ipAddresses.infranode.internal.addressPrefix, '<%= 101 + @infra.keys.find_index(name) %>']",
+              "privateIPAddress": "[concat(variables('network').ipAddresses.infranode.internal.addressPrefix, '<%= 101 + @infra.keys.find_index(name) %>')]",
               "subnet": {
                 "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('network').virtual.name), '/subnets/', variables('network').subnet.name)]"
               }

--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -344,7 +344,7 @@
             "createOption": "FromImage",
             "caching": "ReadWrite",
             "image": {
-              "uri": "<%= name %>"
+              "uri": "<%= _uri %>"
             },
             "vhd": {
               "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/infranode-<%= name %>-osdisk.vhd')]"

--- a/generator_files/wombat.yml
+++ b/generator_files/wombat.yml
@@ -10,6 +10,7 @@ certs: ['automate', 'chef', 'compliance']
 ttl: 6
 linux: ubuntu
 version: 0.2.1
+owner:
 products:
   chef: stable-latest
   chef-server: stable-latest

--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -95,6 +95,19 @@ module Wombat
         resource_group = Azure::ARM::Resources::Models::ResourceGroup.new
         resource_group.location = wombat['azure']['location']
 
+        # Create hash to be used as tags on the resource group
+        tags = {
+          InUse: "true"
+        }
+
+        # If an owner has been sepcified in the wombat file then add this as a tag
+        if wombat.key?('owner') && !wombat['owner'].nil?
+          tags[:owner] = wombat['owner']
+        end
+
+        # add the tags hash to the parameters
+        resource_group.tags = tags
+
         # Create the resource group
         resource_management_client.resource_groups.create_or_update(wombat['name'], resource_group)
       end

--- a/lib/wombat/cli.rb
+++ b/lib/wombat/cli.rb
@@ -106,6 +106,10 @@ module Wombat
             opts.on("--update-template", "Update template") do |opt|
               options.update_template = opt
             end
+
+            opts.on("--async", "Deploy stack asynchronously, e.g. do not block command line.  Only applies to Azure deployments.") do |opt|
+              options.azure_async = opt
+            end
           },
           argv: stack_argv_proc
         },

--- a/lib/wombat/cli.rb
+++ b/lib/wombat/cli.rb
@@ -66,7 +66,7 @@ module Wombat
             end
 
             opts.on("-c CONFIG", "--config CONFIG", "Specify a different yaml config (default is wombat.yml)") do |opt|
-              options.wombat_yaml = opt
+              options.wombat_yml = opt
             end
 
             opts.on("--debug", "Run in debug mode.") do |opt|

--- a/lib/wombat/cli.rb
+++ b/lib/wombat/cli.rb
@@ -149,6 +149,10 @@ module Wombat
             opts.on("-c CLOUD", "--cloud CLOUD", "Select cloud") do |opt|
               options.cloud = opt
             end
+
+            opts.on("--config CONFIG", "Specify a different yaml config (default is wombat.yml)") do |opt|
+              options.wombat_yml = opt
+            end
           },
           argv: file_argv_proc
         }

--- a/lib/wombat/delete.rb
+++ b/lib/wombat/delete.rb
@@ -51,7 +51,7 @@ module Wombat
 
         resource_management_client.resource_groups.begin_delete(stack)
 
-
+        info "Destroy operation accepted and will continue in the background."
       end
     end
   end

--- a/lib/wombat/deploy.rb
+++ b/lib/wombat/deploy.rb
@@ -8,12 +8,14 @@ module Wombat
     include Wombat::Common
 
     attr_reader :stack, :cloud, :lock_opt, :template_opt
+    attr_accessor :resource_management_client
 
     def initialize(opts)
       @stack = opts.stack
       @cloud = opts.cloud.nil? ? "aws" : opts.cloud
       @lock_opt = opts.update_lock
       @template_opt = opts.update_template
+      @azure_async = opts.azure_async
     end
 
     def start
@@ -26,60 +28,132 @@ module Wombat
 
     def create_stack(stack)
 
-    # Deploy the template to the correct stack
-    case @cloud
-    when "aws"
+      # Deploy the template to the correct stack
+      case @cloud
+      when "aws"
 
-      template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
-      cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
+        template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
+        cfn = Aws::CloudFormation::Client.new(region: lock['aws']['region'])
 
-      banner("Creating CloudFormation stack")
-      resp = cfn.create_stack({
-        stack_name: "#{stack}",
-        template_body: template_file,
-        capabilities: ["CAPABILITY_IAM"],
-        on_failure: "DELETE",
-        parameters: [
-          {
-            parameter_key: "KeyName",
-            parameter_value: lock['aws']['keypair'],
-          }
-        ]
-      })
-      puts "Created: #{resp.stack_id}"
-    when "azure"
+        banner("Creating CloudFormation stack")
+        resp = cfn.create_stack({
+          stack_name: "#{stack}",
+          template_body: template_file,
+          capabilities: ["CAPABILITY_IAM"],
+          on_failure: "DELETE",
+          parameters: [
+            {
+              parameter_key: "KeyName",
+              parameter_value: lock['aws']['keypair'],
+            }
+          ]
+        })
+        puts "Created: #{resp.stack_id}"
+      when "azure"
 
-      banner("Creating Azure RM stack")
+        banner("Creating Azure RM stack")
 
-      # determine the path to the arm template
-      template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
+        # determine the path to the arm template
+        template_file = File.read("#{conf['stack_dir']}/#{stack}.json")
 
-      # determine the name of the deployment
-      deployment_name = format('deploy-%s', Time.now().to_i)
+        # determine the name of the deployment
+        deployment_name = format('deploy-%s', Time.now().to_i)
 
-      # Create the connection to Azure using the information in the environment variables
-      subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
-      tenant_id = ENV['AZURE_TENANT_ID']
-      client_id = ENV['AZURE_CLIENT_ID']
-      client_secret = ENV['AZURE_CLIENT_SECRET']
+        # Create the connection to Azure using the information in the environment variables
+        subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
+        tenant_id = ENV['AZURE_TENANT_ID']
+        client_id = ENV['AZURE_CLIENT_ID']
+        client_secret = ENV['AZURE_CLIENT_SECRET']
 
-      token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
-      azure_conn = MsRest::TokenCredentials.new(token_provider)
+        token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+        azure_conn = MsRest::TokenCredentials.new(token_provider)
 
-      # Create a resource client so that the template can be deployed
-      resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
-      resource_management_client.subscription_id = subscription_id
+        # Create a resource client so that the template can be deployed
+        @resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
+        @resource_management_client.subscription_id = subscription_id
 
-      # Create the deployment definition
-      deployment = Azure::ARM::Resources::Models::Deployment.new
-      deployment.properties = Azure::ARM::Resources::Models::DeploymentProperties.new
-      deployment.properties.mode = Azure::ARM::Resources::Models::DeploymentMode::Incremental
-      deployment.properties.template = JSON.parse(template_file)
+        # Create the deployment definition
+        deployment = Azure::ARM::Resources::Models::Deployment.new
+        deployment.properties = Azure::ARM::Resources::Models::DeploymentProperties.new
+        deployment.properties.mode = Azure::ARM::Resources::Models::DeploymentMode::Incremental
+        deployment.properties.template = JSON.parse(template_file)
 
-      # Perform the deployment to the named resource group
-      response = resource_management_client.deployments.create_or_update(stack, deployment_name, deployment)
+        # Perform the deployment to the named resource group
+        begin
+          resource_management_client.deployments.begin_create_or_update_async(stack, deployment_name, deployment).value!
+        rescue MsRestAzure::AzureOperationError => operation_error
+          rest_error = operation_error.body['error']
+          deployment_active = rest_error['code'] == 'DeploymentActive'
+          if deployment_active
+            info format("Deployment for resource group '%s' is ongoing", stack)
+          else
+            warn rest_error
+            raise operation_error
+          end
+        end
 
+        # Monitor the deployment
+        if @azure_async
+          info "Deployment operation accepted.  Use the Azure Portal to check progress"
+        else
+          follow_azure_deployment(stack, deployment_name)
+        end
+
+      end
     end
+
+    # Track the progress of the deployment in Azure
+    #
+    # ===== Attributes
+    #
+    # * +rg_name+ - Name of the resource group being deployed to
+    # * +deployment_name+ - Name of the deployment that is currently being processed
+    def follow_azure_deployment(rg_name, deployment_name)
+
+      end_provisioning_states = 'Canceled,Failed,Deleted,Succeeded'
+      end_provisioning_state_reached = false
+
+      until end_provisioning_state_reached
+        list_outstanding_deployment_operations(rg_name, deployment_name)
+        info ""
+        sleep 10
+        deployment_provisioning_state = deployment_state(rg_name, deployment_name)
+        end_provisioning_state_reached = end_provisioning_states.split(',').include?(deployment_provisioning_state)
+      end
+      info format("Resource Template deployment reached end state of %s", deployment_provisioning_state)
+    end
+
+    # Get a list of the outstanding deployment operations
+    #
+    # ===== Attributes
+    #
+    # * +rg_name+ - Name of the resource group being deployed to
+    # * +deployment_name+ - Name of the deployment that is currently being processed    
+    def list_outstanding_deployment_operations(rg_name, deployment_name)
+      end_operation_states = 'Failed,Succeeded'
+      deployment_operations = resource_management_client.deployment_operations.list(rg_name, deployment_name)
+      deployment_operations.each do |val|
+        resource_provisioning_state = val.properties.provisioning_state
+        unless val.properties.target_resource.nil?
+          resource_name = val.properties.target_resource.resource_name
+          resource_type = val.properties.target_resource.resource_type
+        end
+        end_operation_state_reached = end_operation_states.split(',').include?(resource_provisioning_state)
+        unless end_operation_state_reached
+          info format("resource %s '%s' provisioning status is %s", resource_type, resource_name, resource_provisioning_state)
+        end
+      end
+    end
+
+    # Get the state of the specified deployment
+    #
+    # ===== Attributes
+    #
+    # * +rg_name+ - Name of the resource group being deployed to
+    # * +deployment_name+ - Name of the deployment that is currently being processed     
+    def deployment_state(rg_name, deployment_name)
+      deployments = resource_management_client.deployments.get(rg_name, deployment_name)
+      deployments.properties.provisioning_state
     end
 
   end

--- a/lib/wombat/update.rb
+++ b/lib/wombat/update.rb
@@ -9,6 +9,7 @@ module Wombat
     def initialize(opts)
       @cloud = opts.cloud.nil? ? "aws" : opts.cloud
       @update_file = opts.file.nil? ? "all" : opts.file
+      @wombat_yml = opts.wombat_yml
     end
 
     def start


### PR DESCRIPTION
Multiple updates to fix minor issues and provide more feedback when deploying to Azure

- Infranodes can now be built correctly as have sorted the issue with `ssh_pty`
- In case it is relevant the `sysprep` command for all Windows machines has been separated from the `cd` command
- Corrected issue in Wombat that prevented the use of a different wombat configuration file
- Added tags to the Azure resource group based on the `owner` if it has been specified in the `wombat.yml` file.  Will also add `InUse: true` so that it is not deleted by clean up routines
- Added `--config` argument to the `update` command as it was missing and therefore could not specify a different `wombat.yml` file
- Corrected syntax error in ARM template that prevented deployment
- By default a deployment to Azure will run synchronously and give output in the terminal.  However this can be overridden using `--async` on the command line.  (Thanks to @stuartpreston form much of this code)
- Corrected issue when generating template that meant the URI to the custom image for the infranode was not being set correctly.
