### PR TITLE
Modified the way in which Azure tags can be set

### DIFF
--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -97,13 +97,31 @@ module Wombat
 
         # Create hash to be used as tags on the resource group
         tags = {
-          InUse: "true",
           owner: ENV['USER']
         }
 
         # If an owner has been specified in the wombat file override the owner value
         if wombat.key?('owner') && !wombat['owner'].nil?
           tags[:owner] = wombat['owner']
+        end
+
+        # Determine if there are any tags specified in the azure wmbat section that need to be added
+        if wombat['azure'].key?('tags') && wombat['azure']['tags'].length > 0
+
+          # Check to see if there are more than 15 tags in which case output a warning
+          if wombat['azure']['tags'].length > 15
+            warn ('More than 15 tags have been specified, only the first 15 will be added.  This is a restriction in Azure.')
+          end
+
+          # Iterate around the tags and add each one to the tags array, up to 15
+          wombat['azure']['tags'].each_with_index do |(key, value), index|
+            tags[key] = value
+
+            if index == 14
+              break
+            end
+          end
+
         end
 
         # add the tags hash to the parameters

--- a/lib/wombat/build.rb
+++ b/lib/wombat/build.rb
@@ -109,7 +109,7 @@ module Wombat
         if wombat['azure'].key?('tags') && wombat['azure']['tags'].length > 0
 
           # Check to see if there are more than 15 tags in which case output a warning
-          if wombat['azure']['tags'].length > 15
+          if wombat['azure']['tags'].length > 14
             warn ('More than 15 tags have been specified, only the first 15 will be added.  This is a restriction in Azure.')
           end
 
@@ -117,7 +117,7 @@ module Wombat
           wombat['azure']['tags'].each_with_index do |(key, value), index|
             tags[key] = value
 
-            if index == 14
+            if index == 13
               break
             end
           end


### PR DESCRIPTION
Tags that need to be applied to the resource group can be added the `azure` section of the wombat file.

A default tag is always applied which is the `owner` based on the username or as specified in the wombat file.

Additional tags can be applied thus:

```yaml
azure:
  tags:
    inuse: true
    expiry: 20170214
```

A maximum of 15 tags can be added to a resource group.  As `owner` is always one the code will check that no more than 14 have been specified.  If they have then the rest will be ignored.

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>