### PR TITLE
Enabled outputs for Azure deployments

### DIFF
--- a/lib/wombat/cli.rb
+++ b/lib/wombat/cli.rb
@@ -152,7 +152,11 @@ module Wombat
         outputs: {
           class: OutputRunner,
           parser: OptionParser.new { |opts|
-            opts.banner = "Usage: #{NAME} outputs [TEMPLATE ...]"
+            opts.banner = "Usage: #{NAME} outputs STACK"
+
+            opts.on("-c CLOUD", "--cloud CLOUD", "Select cloud") do |opt|
+              options.cloud = opt
+            end
           },
           argv: stack_argv_proc
         },

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'erb'
 require 'benchmark'
 require 'fileutils'
+require 'ms_rest_azure'
 
 module Wombat
   module Common
@@ -275,6 +276,20 @@ module Wombat
       rescue JSON::ParserError => e
         false
       end
+    end
+
+    # Connect to Azure using environment variables
+    #
+    # 
+    def connect_azure
+
+        # Create the connection to Azure using the information in the environment variables
+        tenant_id = ENV['AZURE_TENANT_ID']
+        client_id = ENV['AZURE_CLIENT_ID']
+        client_secret = ENV['AZURE_CLIENT_SECRET']
+
+        token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+        MsRest::TokenCredentials.new(token_provider)
     end
 
     # Track the progress of the deployment in Azure

--- a/lib/wombat/delete.rb
+++ b/lib/wombat/delete.rb
@@ -1,6 +1,5 @@
 require 'wombat/common'
 require 'aws-sdk'
-require 'ms_rest_azure'
 require 'azure_mgmt_resources'
 
 module Wombat
@@ -37,18 +36,12 @@ module Wombat
 
       when "azure"
 
-        # Create the connection to Azure using the information in the environment variables
-        subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
-        tenant_id = ENV['AZURE_TENANT_ID']
-        client_id = ENV['AZURE_CLIENT_ID']
-        client_secret = ENV['AZURE_CLIENT_SECRET']
-
-        token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
-        azure_conn = MsRest::TokenCredentials.new(token_provider)
+        # Connect to Azure
+        azure_conn = connect_azure()
 
         # Create a resource client so that the resource group can be deleted
         @resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
-        @resource_management_client.subscription_id = subscription_id
+        @resource_management_client.subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
 
         # Only delete the entire resource group if it has been explicitly set
         if (@remove_all) 

--- a/lib/wombat/deploy.rb
+++ b/lib/wombat/deploy.rb
@@ -1,6 +1,5 @@
 require 'wombat/common'
 require 'aws-sdk'
-require 'ms_rest_azure'
 require 'azure_mgmt_resources'
 
 module Wombat
@@ -58,19 +57,13 @@ module Wombat
 
         # determine the name of the deployment
         deployment_name = format('deploy-%s', Time.now().to_i)
-
-        # Create the connection to Azure using the information in the environment variables
-        subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
-        tenant_id = ENV['AZURE_TENANT_ID']
-        client_id = ENV['AZURE_CLIENT_ID']
-        client_secret = ENV['AZURE_CLIENT_SECRET']
-
-        token_provider = MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
-        azure_conn = MsRest::TokenCredentials.new(token_provider)
+        
+        # Connect to azure
+        azure_conn = connect_azure()
 
         # Create a resource client so that the template can be deployed
         @resource_management_client = Azure::ARM::Resources::ResourceManagementClient.new(azure_conn)
-        @resource_management_client.subscription_id = subscription_id
+        @resource_management_client.subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
 
         # Create the deployment definition
         deployment = Azure::ARM::Resources::Models::Deployment.new

--- a/lib/wombat/output.rb
+++ b/lib/wombat/output.rb
@@ -67,6 +67,7 @@ module Wombat
 
       banner(format("Public IP Addresses in '%s'", stack))
 
+      # Check that there are IP addresses in the stack
       if public_ip_addresses.length == 0
 
         warn('No public IP addresses')

--- a/lib/wombat/output.rb
+++ b/lib/wombat/output.rb
@@ -1,18 +1,28 @@
 require 'wombat/common'
 require 'aws-sdk'
+require 'azure_mgmt_network'
 
 module Wombat
   class OutputRunner
     include Wombat::Common
 
-    attr_reader :stack
+    attr_reader :stack, :cloud
+    attr_accessor :network_management_client
 
     def initialize(opts)
       @stack = opts.stack
+      @cloud = opts.cloud.nil? ? "aws" : opts.cloud
     end
 
     def start
-      cfn_workstation_ips(stack)
+
+      # Get the IP addresses for the workstations
+      case cloud
+      when "aws"
+        cfn_workstation_ips(stack)
+      when "azure"
+        azure_workstation_ips(stack)
+      end
     end
 
     private
@@ -41,6 +51,35 @@ module Wombat
         end
       end
       instances
+    end
+
+    def azure_workstation_ips(stack)
+
+      # Connect to Azure
+      azure_conn = connect_azure()
+
+      # Create a resource client so that the template can be deployed
+      @network_management_client = Azure::ARM::Network::NetworkManagementClient.new(azure_conn)
+      network_management_client.subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
+
+      # Obtain a list of all the Public IP addresses in the stack
+      public_ip_addresses = network_management_client.public_ipaddresses.list(stack)
+
+      banner(format("Public IP Addresses in '%s'", stack))
+
+      if public_ip_addresses.length == 0
+
+        warn('No public IP addresses')
+
+      else
+
+        # Iterate around the public IP addresses and output each one
+        public_ip_addresses.each do |public_ip_address|
+
+          # Output the details about the IP address
+          puts format("%s:\t%s (%s)", public_ip_address.name, public_ip_address.ip_address, public_ip_address.dns_settings.fqdn)
+        end
+      end
     end
   end
 end

--- a/wombat-cli.gemspec
+++ b/wombat-cli.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'aws-sdk', '~> 2.5'
   gem.add_dependency 'azure_mgmt_resources', '~> 0.9'
   gem.add_dependency 'azure_mgmt_storage', '~> 0.9'
+  gem.add_dependency 'azure_mgmt_network', '~> 0.9'
 end


### PR DESCRIPTION
The public IP addresses for Azure deployments can now be retrieved using:

```bash
$> wombat outputs -c azure wombat-rg
```

This will output something similar to:

```
==> Public IP Addresses in 'wombat-rg'
Workstation-1-PublicIPAddress:  104.40.184.39 (ws-46zr-1.westeurope.cloudapp.azure.com)
```

This has meant the inclusion of another Azure library to access the public IP addresses in the Resource Group.

Modified the the `output` sub command so that it had the option to specify the cloud.  Also updated the description as it was somewhat misleading as it mentioned templates and not the stack.

The code to connect to Azure has been moved into `common.rb` as this was being used in many places.