### PR TITLE
Remove checksum verification for Google Chrome Chocolatey package

### DIFF
--- a/generator_files/cookbooks/wombat/attributes/default.rb
+++ b/generator_files/cookbooks/wombat/attributes/default.rb
@@ -28,7 +28,6 @@ default['demo']['chef_server_url'] = "https://#{node['demo']['chef_fqdn']}/organ
 default['demo']['compliance_fqdn'] = "#{node['demo']['domain_prefix']}compliance.#{node['demo']['domain']}"
 
 default['demo']['pkgs'] = %w(
-  googlechrome
   atom
   git
   hub

--- a/generator_files/cookbooks/wombat/attributes/default.rb
+++ b/generator_files/cookbooks/wombat/attributes/default.rb
@@ -33,6 +33,7 @@ default['demo']['pkgs'] = %w(
   hub
   gitextensions
   git-credential-manager-for-windows
+  cmder
 )
 
 default['demo']['data_collector_token'] = '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'

--- a/generator_files/cookbooks/wombat/metadata.rb
+++ b/generator_files/cookbooks/wombat/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license 'all_rights'
 description 'Installs/Configures wombat'
 long_description 'Installs/Configures wombat'
-version '0.2.1'
+version '0.2.2'
 
 depends 'hostsfile'
 depends 'apt'

--- a/generator_files/cookbooks/workstation/.kitchen.ec2.yml
+++ b/generator_files/cookbooks/workstation/.kitchen.ec2.yml
@@ -16,7 +16,7 @@ provisioner:
 platforms:
   - name: windows-2012r2
     driver:
-      image_id: ami-1c7ad77c
+      image_id: ami-1562d075
     transport:
       ssh_key: <%= ENV["EC2_SSH_KEY_PATH"] %>
 

--- a/generator_files/cookbooks/workstation/metadata.rb
+++ b/generator_files/cookbooks/workstation/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cheeseplus@chef.io'
 license 'Apache 2.0'
 description 'Configures a Windows workstation'
 long_description 'Configures a Windows workstation'
-version '0.2.6'
+version '0.3.0'
 supports 'windows'
 
 depends 'chocolatey'

--- a/generator_files/cookbooks/workstation/recipes/default.rb
+++ b/generator_files/cookbooks/workstation/recipes/default.rb
@@ -6,10 +6,6 @@ node['demo']['pkgs'].each do |pkg|
   end
 end
 
-chocolatey_package 'cmder' do
-  version '1.3.0'
-end
-
 chocolatey_package 'GoogleChrome' do
   options '--ignorechecksum'
 end

--- a/generator_files/cookbooks/workstation/recipes/default.rb
+++ b/generator_files/cookbooks/workstation/recipes/default.rb
@@ -1,13 +1,17 @@
-include_recipe 'chocolatey'
+include_recipe 'chocolatey::default'
 
 node['demo']['pkgs'].each do |pkg|
-  chocolatey pkg do
-    options ({ '-allow-empty-checksums' => '' })
+  chocolatey_package pkg do
+    options '--allow-empty-checksums'
   end
 end
 
-chocolatey 'cmder' do
+chocolatey_package 'cmder' do
   version '1.3.0'
+end
+
+chocolatey_package 'GoogleChrome' do
+  options '--ignorechecksum'
 end
 
 include_recipe 'workstation::certs-keys'

--- a/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
+++ b/generator_files/cookbooks/workstation/test/integration/default/workstation_spec.rb
@@ -29,7 +29,7 @@ describe command('choco list -l git-credential-manager-for-windows') do
 end
 
 describe command('Get-Module -ListAvailable -Name posh-git') do
-  its(:stdout) { should match(/Script     0.7.0      posh-git/) }
+  its(:stdout) { should match(/Script     0.7.1.0    posh-git/) }
 end
 
 describe file('C:\Users\Administrator\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1') do


### PR DESCRIPTION
Fixes #306
- Separates out the GoogleChrome choco package in order to remove its checksum verification
- Updates the `workstation` cookbook to use the chef-client native `chocolatey_package` resource