### PR TITLE
Added support for Azure Managed Disks

### DIFF
--- a/generator_files/packer/workstation.json
+++ b/generator_files/packer/workstation.json
@@ -63,6 +63,7 @@
             "image_publisher": "{{ user `azure_image_publisher` }}",
             "image_offer": "{{ user `azure_image_offer` }}",
             "image_sku": "{{ user `azure_image_sku` }}",
+            "image_version": "{{ user `azure_image_version` }}",
             "location": "{{user `azure_location`}}",
             "vm_size": "Standard_DS3_v2",
             "communicator": "winrm",

--- a/generator_files/templates/arm.json.erb
+++ b/generator_files/templates/arm.json.erb
@@ -174,12 +174,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "Workstation-<%= i.to_s %>-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= @workstation_ami[i] %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },   
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "Workstation-<%= i.to_s %>-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/Workstation-<%= i.to_s %>-NIC"
+        "Microsoft.Network/networkInterfaces/Workstation-<%= i.to_s %>-NIC",
+        "Microsoft.Compute/images/Workstation-<%= i.to_s %>-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Workstation <%= i.to_s %>')]"
@@ -194,17 +213,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "workstation-<%= i.to_s %>-osdisk",
-            "osType": "windows",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= @workstation_ami[i] %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/workstation-<%= i.to_s %>-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'Workstation-<%= i.to_s %>-VM-Image')]"
           }
         },
         "networkProfile": {
@@ -246,12 +256,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "BuildNode-<%= i.to_s %>-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= @build_node_ami[i] %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },    
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "BuildNode-<%= i.to_s %>-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/BuildNode-<%= i.to_s %>-NIC"
+        "Microsoft.Network/networkInterfaces/BuildNode-<%= i.to_s %>-NIC",
+        "Microsoft.Compute/images/BuildNode-<%= i.to_s %>-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Build Node <%= i.to_s %>')]"
@@ -266,17 +295,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "buildnode-<%= i.to_s %>-osdisk",
-            "osType": "linux",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= @build_node_ami[i] %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/buildnode-<%= i.to_s %>-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'BuildNode-<%= i.to_s %>-VM-Image')]"
           }
         },
         "networkProfile": {
@@ -318,12 +338,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "InfraNode-<%= name %>-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= _uri %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "InfraNode-<%= name %>-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/InfraNode-<%= name %>-NIC"
+        "Microsoft.Network/networkInterfaces/InfraNode-<%= name %>-NIC",
+        "Microsoft.Compute/images/InfraNode-<%= name %>-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Infra Node - <%= name %>')]"
@@ -338,17 +377,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "infranode-<%= name %>-osdisk",
-            "osType": "linux",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= _uri %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/infranode-<%= name %>-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'InfraNode-<%= name %>-VM-Image')]"
           }
         },
         "networkProfile": {
@@ -388,12 +418,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "ChefServer-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= @chef_server_uri %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "ChefServer-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/ChefServer-NIC"
+        "Microsoft.Network/networkInterfaces/ChefServer-NIC",
+        "Microsoft.Compute/images/ChefServer-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Chef Server')]"
@@ -409,17 +458,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "chefserver-osdisk",
-            "osType": "linux",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= @chef_server_uri %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/chefserver-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'ChefServer-VM-Image')]"
           }
         },
         "networkProfile": {
@@ -457,12 +497,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "AutomateServer-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= @automate_uri %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "AutomateServer-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/AutomateServer-NIC"
+        "Microsoft.Network/networkInterfaces/AutomateServer-NIC",
+        "Microsoft.Compute/images/AutomateServer-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Automate Server')]"
@@ -478,17 +537,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "automateserver-osdisk",
-            "osType": "linux",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= @automate_uri %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/automate-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'AutomateServer-VM-Image')]"
           }
         },
         "networkProfile": {
@@ -526,12 +576,31 @@
     },
 
     {
+      "type": "Microsoft.Compute/images",
+      "apiVersion": "2016-04-30-preview",
+      "name": "ComplianceServer-VM-Image",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "blobUri": "<%= @compliance_uri %>",
+            "caching": "ReadWrite",
+            "storageAccountType": "Standard_LRS"
+          },
+          "dataDisks": []
+        }
+      }
+    },
+
+    {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "ComplianceServer-VM",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2016-04-30-preview",
       "location": "[variables('location')]",
       "dependsOn": [
-        "Microsoft.Network/networkInterfaces/ComplianceServer-NIC"
+        "Microsoft.Network/networkInterfaces/ComplianceServer-NIC",
+        "Microsoft.Compute/images/ComplianceServer-VM-Image"
       ],
       "tags": {
         "name": "[concat(parameters('demoName'), ' Compliance Server')]"
@@ -547,17 +616,8 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "name": "complianceserver-osdisk",
-            "osType": "linux",
-            "createOption": "FromImage",
-            "caching": "ReadWrite",
-            "image": {
-              "uri": "<%= @compliance_uri %>"
-            },
-            "vhd": {
-              "uri": "[concat('https://', variables('sa').name, '.blob.core.windows.net/', variables('sa').container, '/compliance-osdisk.vhd')]"
-            }
+          "imageReference": {
+            "id": "[resourceId('Microsoft.Compute/images', 'ComplianceServer-VM-Image')]"
           }
         },
         "networkProfile": {

--- a/lib/wombat/common.rb
+++ b/lib/wombat/common.rb
@@ -60,7 +60,7 @@ module Wombat
               when 'gcp'
                 'A disk image was created:'
               when 'azure'
-                'OSDiskUri:'
+                'ManagedDiskOSDiskUri:'
               else
                 "#{wombat['aws']['region']}:"
               end

--- a/wombat-cli.gemspec
+++ b/wombat-cli.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'azure_mgmt_resources', '~> 0.9'
   gem.add_dependency 'azure_mgmt_storage', '~> 0.9'
   gem.add_dependency 'azure_mgmt_network', '~> 0.9'
+  gem.add_dependency 'azure-storage', '~> 0.11'
 end


### PR DESCRIPTION
The build phase of wombat has been modified for Azure so that when Packer has completed the build of the custom image(s) they are copied to a top level container.  This is a requirement of creating a Managed Disk Image.  It also modifies the log file for each machine with the updated URL to the custom image.  This has to be done because Packer does not _yet_ have native support for Managed Disks.

The ARM template has been updated to create a Managed Disk Images from the custom image.  From this the virtual machines have a reference to their specific image.

When the deployment is run Azure will create the 'Disk Image' and then the disks for each of the machines.  This results in many more resources but they are now all first class resources in the Resource Group.

![image](https://cloud.githubusercontent.com/assets/791658/23453958/5a031f62-fe62-11e6-8d1b-4e4e6ea0ba4d.png)

One side effect of using Managed Disks should be that they can be reused elsewhere.  This will need investigation.

As the Disk Image has been created from the Packer custom image, it is probably possible to delete the custom images once the template has been run, again something that needs to be investigated.


Closes #309

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>