### PR TITLE
create file to disable telemetry

### DIFF
--- a/generator_files/cookbooks/automate/recipes/default.rb
+++ b/generator_files/cookbooks/automate/recipes/default.rb
@@ -43,6 +43,10 @@ directory '/etc/delivery' do
   mode '0644'
 end
 
+file '/var/opt/delivery/.telemetry.disabled' do
+  action :create
+end
+
 file '/etc/delivery/automate.pem' do
   content lazy { IO.read('/tmp/private.pem') }
   action :create


### PR DESCRIPTION
telemetry will cause an additional notification box on opening up the automate ui, instead of clicking that each time lets disable it!