### PR TITLE
remove hardcoded cert import loop

### DIFF
--- a/generator_files/cookbooks/workstation/recipes/certs-keys.rb
+++ b/generator_files/cookbooks/workstation/recipes/certs-keys.rb
@@ -19,7 +19,7 @@ template "#{home}/.ssh/config" do
   )
 end
 
-%w(chef automate compliance).each do |f|
+node['demo']['certs'].each do |f|
   file "#{home}/.chef/trusted_certs/#{node['demo']['domain_prefix']}#{f}_#{node['demo']['domain'].tr('.','_')}.crt" do
     content  lazy { IO.read("C:/Windows/Temp/#{f}.crt") }
     action :create


### PR DESCRIPTION
we know what certs to import by iterating off the config value, this way we can import any cert we create