### PR TITLE
Slow and steady wins the overextended metaphor. (Sleeps for rabbit)

### DIFF
--- a/generator_files/cookbooks/automate/metadata.rb
+++ b/generator_files/cookbooks/automate/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license 'all_rights'
 description 'Installs/Configures automate'
 long_description 'Installs/Configures automate'
-version '0.2.1'
+version '0.2.2'
 
 depends 'chef-ingredient'
 depends 'line'

--- a/generator_files/cookbooks/automate/recipes/default.rb
+++ b/generator_files/cookbooks/automate/recipes/default.rb
@@ -81,9 +81,17 @@ template '/etc/delivery/delivery.rb' do
   )
 end
 
+# Addresses an edge case where rabbit times out on the reconfigure.
+execute 'Give delivery time to start up' do
+  command 'sleep 300'
+  action :run
+end
+
 execute 'delivery-ctl reconfigure' do
   command 'delivery-ctl reconfigure'
   action :run
+  retries 5
+  retry_delay 10
 end
 
 execute 'delivery-ctl create-enterprise' do


### PR DESCRIPTION
Inserts a sleep to give delivery enough time to spin up before reconfiguring. 
Also adds some retries to the reconfigure. 